### PR TITLE
Require at least Rust 1.51.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ num = "^0.3"
 routecore = { version = "0.0.2-dev", features = ["serde"] }
 rustyline = {version = "8.0.0", optional = true}
 
+[build-dependencies]
+rustc_version = "^0.4"
+
 [features]
 cli = ["csv", "ansi_term", "rustyline"]
 default = []

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+extern crate rustc_version;
+use rustc_version::{Version, version};
+
+fn main() {
+    let version = version().expect("Failed to get rustc version.");
+    if version < Version::parse("1.51.0").unwrap() {
+        eprintln!(
+            "\n\nAt least Rust version 1.51 is required.\n\
+             Version {} is used for building.\n\
+             Build aborted.\n\n",
+             version);
+        panic!();
+    }
+}


### PR DESCRIPTION
Rust 1.51.0 stabilized the 'min_const_generics' feature that is required for compilation to succeed.