### PR TITLE
Fix more specifics example

### DIFF
--- a/examples/more_specifics.rs
+++ b/examples/more_specifics.rs
@@ -7,7 +7,7 @@ use routecore::addr::Prefix;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // type StoreType = InMemStorage<u32, PrefixAs>;
     let mut tree_bitmap =
-        MultiThreadedStore::<PrefixAs>::new(vec![4], vec![8]);
+        MultiThreadedStore::<PrefixAs>::new(vec![4], vec![4]);
     let pfxs = vec![
         Prefix::new_relaxed(
             0b0000_0000_0000_0000_0000_0000_0000_0000_u32.into_ipaddr(),


### PR DESCRIPTION
Only certain stride sizes are supported by the `cht_work` branch which causes the `more_specifics` example to fail. Use the valid stride size used for IPv4 also for IPv6.