### PR TITLE
Really fix numbers treebitmap example

### DIFF
--- a/examples/numbers_treebitmap.rs
+++ b/examples/numbers_treebitmap.rs
@@ -49,7 +49,6 @@ fn load_prefixes(
 fn main() -> Result<(), Box<dyn Error>> {
     let strides_vec = [
         vec![4, 4, 4, 4, 4, 4, 4, 4],
-        vec![6, 6, 6, 6, 4, 4],
     ];
 
     for strides in strides_vec.iter() {

--- a/examples/numbers_treebitmap.rs
+++ b/examples/numbers_treebitmap.rs
@@ -49,6 +49,7 @@ fn load_prefixes(
 fn main() -> Result<(), Box<dyn Error>> {
     let strides_vec = [
         vec![4, 4, 4, 4, 4, 4, 4, 4],
+        vec![3, 4, 5, 4],
     ];
 
     for strides in strides_vec.iter() {


### PR DESCRIPTION
Only stride sizes 3, 4 and 5 are supported. 6 should not have been used.

Without size 6 there remained only one iteration of the main loop in the example, so I invented (i.e. is not in the blog article) a stride vec that also uses stride sizes 3 and 5 to exercise the other supported stride sizes.