### PR TITLE
Fix exact matches example.

### DIFF
--- a/examples/exact_matches.rs
+++ b/examples/exact_matches.rs
@@ -5,7 +5,7 @@ use routecore::addr::Prefix;
 use routecore::record::NoMeta;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut tree_bitmap = MultiThreadedStore::<NoMeta>::new(vec![4], vec![8]);
+    let mut tree_bitmap = MultiThreadedStore::<NoMeta>::new(vec![4], vec![4]);
     let pfxs = vec![
         Prefix::new_relaxed(
             0b0000_0000_0000_0000_0000_0000_0000_0000_u32.into_ipaddr(),


### PR DESCRIPTION
Only stride sizes 3, 4 and 5 are now supported.