### PR TITLE
Initial attempt at a Criterion based benchmark.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,14 @@ array-init = "2.0.0"
 [build-dependencies]
 rustc_version = "^0.4"
 
+[dev-dependencies]
+criterion = "0.3"
+csv = {version = "^1.1"}
+
+[[bench]]
+name = "my_benchmark"
+harness = false
+
 [features]
 cli = ["csv", "ansi_term", "rustyline"]
 default = []

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ IP prefixes storage and retrieval
 Data structure to store IPv4/6 prefixes in a tree bitmap. Part of the Rotonda modular BGP engine.
 
 Read more about the data-structure in this [blog post](https://blog.nlnetlabs.nl/donkeys-mules-horses/).
+
+To run the benchmarks do:
+
+```
+$ cargo install cargo-criterion
+$ cargo criterion
+```
+
+Then open `target/criterion/reports/index.html` in your browser. 

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -1,0 +1,141 @@
+use std::{error::Error, fs::File};
+
+use criterion::{criterion_group, criterion_main, Criterion, SamplingMode, Throughput, BenchmarkId};
+use rotonda_store::{bgp::PrefixRecord, PrefixAs, addr::Prefix, MultiThreadedStore, record::Record, MatchOptions, MatchType};
+
+// These constants are all contingent on the exact csv file,
+// being loaded!
+const CSV_FILE_PATH: &str = "./data/uniq_pfx_asn_dfz_rnd.csv";
+const SEARCHES_NUM: u64 = 2080800;
+const INSERTS_NUM: u64 = 893943;
+const GLOBAL_PREFIXES_VEC_SIZE: usize = 886117;
+const FOUND_PREFIXES: u64 = 1322993;
+
+fn load_prefixes(csv_path: &str) -> Result<Vec<PrefixRecord<PrefixAs>>, Box<dyn Error>> {
+    let file = File::open(csv_path)?;
+    let mut pfxs = Vec::new();
+
+    let mut rdr = csv::Reader::from_reader(file);
+    for result in rdr.records() {
+        let record = result?;
+        let ip: Vec<_> = record[0]
+            .split('.')
+            .map(|o| -> u8 { o.parse().unwrap() })
+            .collect();
+        let net = std::net::Ipv4Addr::new(ip[0], ip[1], ip[2], ip[3]);
+        let len: u8 = record[1].parse().unwrap();
+        let asn: u32 = record[2].parse().unwrap();
+        let pfx = PrefixRecord::new_with_local_meta(
+            Prefix::new(net.into(), len)?,
+            PrefixAs(asn),
+        );
+        pfxs.push(pfx);
+    }
+
+    Ok(pfxs)
+}
+
+fn create_tree_from_prefixes(strides: &[u8], pfxs: &[PrefixRecord<PrefixAs>]) -> Result<MultiThreadedStore::<PrefixAs>, Box<dyn Error>> {
+    let mut tree_bitmap = MultiThreadedStore::<PrefixAs>::new(
+        strides.to_vec(),
+        vec![4],
+    );
+
+    let inserts_num = pfxs.len() as u64;
+    for pfx in pfxs.into_iter() {
+        tree_bitmap.insert(&pfx.prefix, *pfx.meta)?;
+    }
+    assert_eq!(inserts_num, INSERTS_NUM);
+
+    Ok(tree_bitmap)
+}
+
+fn lookup_every_ipv4_prefix(tree_bitmap: &MultiThreadedStore::<PrefixAs>) -> Result<(), Box<dyn Error>> {
+    let inet_max = 255;
+    let len_max = 32;
+
+    let mut found_counter = 0_u64;
+    let mut not_found_counter = 0_u64;
+    (0..inet_max).into_iter().for_each(|i_net| {
+        (0..len_max).into_iter().for_each(|s_len| {
+            (0..inet_max).into_iter().for_each(|ii_net| {
+                let pfx = Prefix::new_relaxed(
+                    std::net::Ipv4Addr::new(i_net, ii_net, 0, 0)
+                        .into(),
+                    s_len,
+                );
+                // print!(":{}.{}.0.0/{}:", i_net, ii_net, s_len);
+                let res = tree_bitmap.match_prefix(
+                    &pfx.unwrap(),
+                    &MatchOptions {
+                        match_type: MatchType::LongestMatch,
+                        include_less_specifics: false,
+                        include_more_specifics: false,
+                    },
+                );
+                if let Some(_pfx) = res.prefix {
+                    // println!("_pfx {:?}", _pfx);
+                    // println!("pfx {:?}", pfx);
+                    // println!("{:#?}", res);
+                    assert!(_pfx.len() <= pfx.unwrap().len());
+                    assert!(_pfx.addr() <= pfx.unwrap().addr());
+                    found_counter += 1;
+                } else {
+                    not_found_counter += 1;
+                }
+            });
+        });
+    });
+    // println!("found pfx: {}", found_counter);
+    // println!("not found pfx: {}", not_found_counter);
+
+    let searches_num =
+        inet_max as u128 * inet_max as u128 * len_max as u128;
+
+    assert_eq!(searches_num, SEARCHES_NUM as u128);
+    assert_eq!(tree_bitmap.prefixes_len(), GLOBAL_PREFIXES_VEC_SIZE);
+    assert_eq!(found_counter, FOUND_PREFIXES);
+    assert_eq!(not_found_counter, SEARCHES_NUM - FOUND_PREFIXES);
+    Ok(())
+}
+
+fn bench(c: &mut Criterion) {
+    let stride_sets = vec![
+        vec![4],
+        vec![3, 4, 5, 4],
+        vec![3, 3, 3, 3, 3, 3, 3, 3, 4, 4],
+        vec![5, 5, 4, 3, 3, 3, 3, 3, 3],
+        ];
+
+    let pfxs = load_prefixes(CSV_FILE_PATH).expect("Failed to load CSV data");
+
+    let mut group = c.benchmark_group("tree insertion");
+    for strides in &stride_sets {
+        let iteration_name = format!("{:?}", strides);
+        group.sampling_mode(SamplingMode::Auto);
+        group.throughput(Throughput::Elements(INSERTS_NUM));
+        group.bench_with_input(BenchmarkId::from_parameter(iteration_name), &strides, |b, strides| {
+            b.iter(|| create_tree_from_prefixes(strides, &pfxs).expect(&format!("Failed to create tree from prefixes with strides {:?}", strides)))
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("tree search");
+    for strides in &stride_sets {
+        let iteration_name = format!("{:?}", strides);
+        let tree = create_tree_from_prefixes(&strides, &pfxs).expect(&format!("Failed to create tree from prefixes with strides {:?}", strides));
+        group.sampling_mode(SamplingMode::Auto);
+        group.throughput(Throughput::Elements(SEARCHES_NUM));
+        group.bench_with_input(BenchmarkId::from_parameter(iteration_name), &tree, |b, tree| {
+            b.iter(|| lookup_every_ipv4_prefix(tree).expect(&format!("Failed to search tree with strides {:?}", strides)))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!{
+    name = benches;
+    config = Criterion::default().sample_size(20);
+    targets = bench
+}
+criterion_main!(benches);

--- a/src/local_array/macros.rs
+++ b/src/local_array/macros.rs
@@ -122,10 +122,10 @@ macro_rules! match_node_for_strides {
                                             cur_serial if cur_serial == new_serial => {
                                                 let found_prefix_id_clone = found_prefix_id.clone();
                                                 $self.store.update_node($cur_i,SizedStrideNode::$variant(current_node));
-                                                println!(
-                                                    "removing old prefix with serial {}...",
-                                                    newer_serial
-                                                );
+                                                // println!(
+                                                //     "removing old prefix with serial {}...",
+                                                //     newer_serial
+                                                // );
                                                 $self.store.remove_prefix(found_prefix_id_clone.set_serial(newer_serial));
                                                 return Ok(());
                                             },
@@ -198,10 +198,10 @@ macro_rules! match_node_for_strides {
                                         let found_prefix_id_clone = found_prefix_id.clone();
                                         // current_node.pfx_vec.insert(pfx_vec_index, found_prefix_id_clone.set_serial(new_serial));
                                         $self.store.update_node($cur_i,SizedStrideNode::$variant(current_node));
-                                        println!(
-                                            "removing old prefix with serial {}...",
-                                            old_serial
-                                        );
+                                        // println!(
+                                        //     "removing old prefix with serial {}...",
+                                        //     old_serial
+                                        // );
                                         $self.store.remove_prefix(found_prefix_id_clone.set_serial(old_serial));
                                         // println!("current_node.pfx_vec {:?}", current_node.pfx_vec);
                                         return Ok(());

--- a/src/local_array/query.rs
+++ b/src/local_array/query.rs
@@ -509,7 +509,7 @@ where
         let mut match_type: MatchType = MatchType::EmptyMatch;
         let mut prefix = None;
         if let Some(pfx_idx) = match_prefix_idx {
-            println!("prefix {}/{} serial {}", pfx_idx.get_net().into_ipaddr(), pfx_idx.get_len(), pfx_idx.0.unwrap().2);
+            // println!("prefix {}/{} serial {}", pfx_idx.get_net().into_ipaddr(), pfx_idx.get_len(), pfx_idx.0.unwrap().2);
             prefix = self.retrieve_prefix(pfx_idx);
             match_type = if prefix.unwrap().len == search_pfx.len {
                 MatchType::ExactMatch

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -752,10 +752,10 @@ where
                         new_serial,
                         &new_meta,
                     )?;
-                    println!(
-                        "removing old default route prefix with serial {}...",
-                        old_serial
-                    );
+                    // println!(
+                    //     "removing old default route prefix with serial {}...",
+                    //     old_serial
+                    // );
                     self.store
                         .remove_prefix(pfx_idx_clone.set_serial(old_serial));
                     return Ok(());


### PR DESCRIPTION
See the additions to `README.md` for guidance on running the benchmark.

Note that it appears [from the Criterion documentation](https://bheisler.github.io/criterion.rs/book/iai/comparison.html) that it might be advisable to use `iai` instead of `criterion` for benchmarks run in a CI environment like GitHub Actions:

> If you absolutely need to pick one or the other though, Iai is probably the one to go with.

However, the documentation and capabilities of `iai` seem to be very limited and these benchmarks are comparatively long running and perhaps less susceptible to distortion of the results, so I'm not sure about this.

## Command line output:

```
$ cargo criterion
   Compiling rotonda-store v0.3.0-dev (/run/media/ximon/NewHome/src/rotonda-store)
...
    Finished bench [optimized] target(s) in 4.68s
Benchmarking tree insertion/[4]: Warming up for 3.0000 s
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 18.4s, or reduce sample count to 10.
tree insertion/[4]      time:   [863.52 ms 872.47 ms 882.47 ms]                             
                        thrpt:  [1.0130 Melem/s 1.0246 Melem/s 1.0352 Melem/s]
                 change:
                        time:   [-5.6231% -4.3701% -3.1893%] (p = 0.00 < 0.05)
                        thrpt:  [+3.2943% +4.5698% +5.9582%]
                        Performance has improved.
Benchmarking tree insertion/[3, 4, 5, 4]: Warming up for 3.0000 s
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 30.4s, or reduce sample count to 10.
tree insertion/[3, 4, 5, 4]                                                                          
                        time:   [1.3017 s 1.3141 s 1.3306 s]
                        thrpt:  [671.83 Kelem/s 680.28 Kelem/s 686.77 Kelem/s]
                 change:
                        time:   [-0.1193% +1.0924% +2.5968%] (p = 0.12 > 0.05)
                        thrpt:  [-2.5311% -1.0806% +0.1194%]
                        No change in performance detected.
Benchmarking tree insertion/[3, 3, 3, 3, 3, 3, 3, 3, 4, 4]: Warming up for 3.0000 s
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 26.9s, or reduce sample count to 10.
tree insertion/[3, 3, 3, 3, 3, 3, 3, 3, 4, 4]                                                                          
                        time:   [1.1309 s 1.2603 s 1.4559 s]
                        thrpt:  [613.99 Kelem/s 709.34 Kelem/s 790.47 Kelem/s]
                 change:
                        time:   [+9.7783% +21.993% +41.776%] (p = 0.00 < 0.05)
                        thrpt:  [-29.466% -18.028% -8.9073%]
...
```

## HTML output:

![image](https://user-images.githubusercontent.com/3304436/150028473-d5b5af0e-29ed-4f87-b188-b1372e875392.png)

![image](https://user-images.githubusercontent.com/3304436/150028771-6cf51d18-d3db-4af7-88d8-4568fc766a99.png)

![image](https://user-images.githubusercontent.com/3304436/150028854-af24d30e-780c-4047-89a3-0b272b3b621a.png)
