### PR TITLE
retry for retrieve_node_mut_with_guard in insert

### DIFF
--- a/src/local_array/macros.rs
+++ b/src/local_array/macros.rs
@@ -84,9 +84,11 @@ macro_rules! match_node_for_strides {
                 }
             } else {
                 // BACKOFF SHOULD BE IMPLEMENTED HERE.
-                trace!("Couldn't load id {} from store l{}. Trying again.",
-                        $cur_i,
-                        $self.store.get_stride_sizes()[$level as usize]);
+                if log_enabled!(Trace) {
+                    trace!("Couldn't load id {} from store l{}. Trying again.",
+                            $cur_i,
+                            $self.store.get_stride_sizes()[$level as usize]);
+                }
             }
         }
     };

--- a/src/local_array/macros.rs
+++ b/src/local_array/macros.rs
@@ -27,13 +27,13 @@ macro_rules! match_node_for_strides {
         // context, one thread creating the node may be outpaced by a thread
         // reading the same node. Because the creation of a node actually
         // consists of two independent atomic operations (first setting the
-        // right bit in the parent bitarry, second storing the node in the
+        // correct bit in the parent bitarry, second storing the node in the
         // store with the meta-data), a thread creating a new node may have
-        // altered the parent bitarray, but not it didn't create the node
-        // in the store yet. The reading thread, however, saw the bit in the
-        // parent and wants to read the node in the store, but that doesn't
-        // exist yet. In that case, the reader thread needs to try again
-        // until it is actually created.
+        // altered the parent bitarray, but it didn't create the node in the
+        // store yet. The reading thread, however, saw the bit in the parent
+        // and wants to read the node in the store, but that doesn't exist
+        // yet. In that case, the reader thread needs to try again until it
+        // is actually created.
         loop {
             if let Some(current_node) = $self.store.retrieve_node_mut_with_guard($cur_i, $guard) {
                 match current_node {

--- a/src/local_array/store/custom_alloc.rs
+++ b/src/local_array/store/custom_alloc.rs
@@ -850,7 +850,7 @@ impl<
                 trace!("retrieve prefix with guard");
 
                 let mut prefixes =
-                    prefix_set.0.load(Ordering::Relaxed, guard);
+                    prefix_set.0.load(Ordering::SeqCst, guard);
                 // trace!("nodes {:?}", unsafe { unwrapped_nodes.deref_mut().len() });
                 trace!(
                     "prefixes at level {}? {:?}",
@@ -861,7 +861,7 @@ impl<
                 let stored_prefix = unsafe { prefix_ref.assume_init_mut() };
 
                 match unsafe {
-                    stored_prefix.0.load(Ordering::Relaxed, guard).deref_mut()
+                    stored_prefix.0.load(Ordering::SeqCst, guard).deref_mut()
                 } {
                     (_serial, Some(pfx_rec), next_set, _prev_record) => {
                         if id == PrefixId::new(pfx_rec.net, pfx_rec.len) {

--- a/src/local_array/store/custom_alloc.rs
+++ b/src/local_array/store/custom_alloc.rs
@@ -801,7 +801,7 @@ impl<
                             pfx_id
                         );
                         // Try again. TODO: backoff neeeds to be implemented
-                        // hers.
+                        // here.
                         (update_meta.f)(
                             update_meta,
                             store_error.current.into(),

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -1,5 +1,5 @@
 use crossbeam_epoch::{self as epoch};
-use log::{info, trace};
+use log::{info, trace, log_enabled, Level::Trace};
 use routecore::record::{MergeUpdate, Meta};
 
 use std::hash::Hash;


### PR DESCRIPTION
Create a retry loop, instead of just unwrapping the `retrieve_node_mut_with_guard` call.