### PR TITLE
Retry prefix insert

### DIFF
--- a/examples/multi_thread_3.rs
+++ b/examples/multi_thread_3.rs
@@ -41,7 +41,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     match tree_bitmap
                         .insert(&pfx.unwrap(), PrefixAs(i as u32))
                     {
-                        Ok(_) => {}
+                        Ok(retry_count) => {
+                            if retry_count > 0  {
+                                println!("{} {:?} retry count {},", std::thread::current().name().unwrap(), pfx, retry_count);
+                            }
+                        }
                         Err(e) => {
                             println!("{}", e);
                         }

--- a/examples/multi_thread_4.rs
+++ b/examples/multi_thread_4.rs
@@ -75,7 +75,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             &pfx.unwrap(),
                             ComplexPrefixAs([i as u32].to_vec()),
                         ) {
-                            Ok(_) => {}
+                            Ok(retry_count) => {
+                                if retry_count > 0 {
+                                    println!("{} {:?} retry count: {},", std::thread::current().name().unwrap(), pfx,retry_count);
+                                }
+                            }
                             Err(e) => {
                                 println!("{}", e);
                             }

--- a/src/local_array/store/errors.rs
+++ b/src/local_array/store/errors.rs
@@ -4,7 +4,6 @@ use std::fmt;
 pub enum PrefixStoreError {
     NodeCreationMaxRetryError,
     NodeNotFound,
-    PrefixAlreadyExist,
 }
 
 impl std::error::Error for PrefixStoreError {}
@@ -19,9 +18,6 @@ impl fmt::Display for PrefixStoreError {
             PrefixStoreError::NodeNotFound => {
                 write!(f, "Error: Node not found.")
             },
-            PrefixStoreError::PrefixAlreadyExist => {
-                write!(f, "Error: Prefix already exists.")
-            }
         }
     }
 }


### PR DESCRIPTION
This PR does two things:

*   Create a compare\_exchange update loop in the case a (first) prefix insertion was outrun by another thread. This gets rid of the PrefixAlreadyExists error.
*   Changes the API for `insert()` to return a Result\<u32, \_> instead of the former Result\<(), _\>,_ where the u32 is the accumulated retry count for all compare\_exchanges involved in the upsert of the prefix