### PR TITLE
Exact match behavior change

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -226,10 +226,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 let query_result = tree_bitmap.match_prefix(
                                     &p,
                                     &MatchOptions {
-                                        match_type: MatchType::LongestMatch,
+                                        match_type: MatchType::ExactMatch,
                                         include_all_records: true,
-                                        include_less_specifics: false,
-                                        include_more_specifics: false,
+                                        include_less_specifics: true,
+                                        include_more_specifics: true,
                                     },
                                     guard,
                                 );
@@ -287,10 +287,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         &Prefix::new_relaxed(ip, len)?,
                                         &MatchOptions {
                                             match_type:
-                                                MatchType::LongestMatch,
+                                                MatchType::ExactMatch,
                                             include_all_records: true,
-                                            include_less_specifics: false,
-                                            include_more_specifics: false
+                                            include_less_specifics: true,
+                                            include_more_specifics: true
                                         },
                                         guard
                                     )

--- a/src/local_array/macros.rs
+++ b/src/local_array/macros.rs
@@ -191,8 +191,8 @@ macro_rules! impl_primitive_atomic_stride {
                 fn into_node_id<AF: AddressFamily>(
                     addr_bits: AF,
                     len: u8
-                ) -> crate::local_array::node::StrideNodeId<AF> {
-                    let id = crate::local_array::node::StrideNodeId::new_with_cleaned_id(addr_bits, len);
+                ) -> $crate::local_array::node::StrideNodeId<AF> {
+                    let id = $crate::local_array::node::StrideNodeId::new_with_cleaned_id(addr_bits, len);
                     id
                 }
 

--- a/src/local_array/node.rs
+++ b/src/local_array/node.rs
@@ -665,7 +665,7 @@ pub(crate) struct NodeChildIter<AF: AddressFamily, S: Stride> {
    _af: PhantomData<AF>,
 }
 
-impl<'a, AF: AddressFamily, S: Stride> std::iter::Iterator for
+impl<AF: AddressFamily, S: Stride> std::iter::Iterator for
     NodeChildIter<AF, S>
 {
     type Item = StrideNodeId<AF>;
@@ -746,7 +746,7 @@ pub(crate) struct NodeMoreSpecificChildIter<AF: AddressFamily, S: Stride> {
    _af: PhantomData<AF>,
 }
 
-impl<'a, AF: AddressFamily, S: Stride> std::iter::Iterator for
+impl<AF: AddressFamily, S: Stride> std::iter::Iterator for
     NodeMoreSpecificChildIter<AF, S>
 {
     type Item = StrideNodeId<AF>;
@@ -810,19 +810,19 @@ impl<'a, AF: AddressFamily, S: Stride> std::iter::Iterator for
     }
 }
 
-impl<'a, AF: AddressFamily> NodeMoreSpecificChildIter<AF, Stride3> {
+impl<AF: AddressFamily> NodeMoreSpecificChildIter<AF, Stride3> {
     pub fn wrap(self) -> SizedNodeMoreSpecificIter<AF> {
         SizedNodeMoreSpecificIter::<AF>::Stride3(self)
     }
 }
 
-impl<'a, AF: AddressFamily> NodeMoreSpecificChildIter<AF, Stride4> {
+impl<AF: AddressFamily> NodeMoreSpecificChildIter<AF, Stride4> {
     pub fn wrap(self) -> SizedNodeMoreSpecificIter<AF> {
         SizedNodeMoreSpecificIter::<AF>::Stride4(self)
     }
 }
 
-impl<'a, AF: AddressFamily> NodeMoreSpecificChildIter<AF, Stride5> {
+impl<AF: AddressFamily> NodeMoreSpecificChildIter<AF, Stride5> {
     pub fn wrap(self) -> SizedNodeMoreSpecificIter<AF> {
         SizedNodeMoreSpecificIter::<AF>::Stride5(self)
     }
@@ -865,7 +865,7 @@ pub(crate) struct NodePrefixIter<AF: AddressFamily, S: Stride> {
     _s: PhantomData<S>,
 }
 
-impl<'a, AF: AddressFamily, S: Stride> std::iter::Iterator for 
+impl<AF: AddressFamily, S: Stride> std::iter::Iterator for 
     NodePrefixIter<AF, S> {
         type Item = PrefixId<AF>;
 
@@ -952,7 +952,7 @@ pub(crate) struct NodeMoreSpecificsPrefixIter<AF: AddressFamily, S: Stride> {
     _s: PhantomData<S>,
 }
 
-impl<'a, AF: AddressFamily, S: Stride> std::iter::Iterator for 
+impl<AF: AddressFamily, S: Stride> std::iter::Iterator for 
     NodeMoreSpecificsPrefixIter<AF, S> {
         type Item = PrefixId<AF>;
 
@@ -1062,19 +1062,19 @@ impl<'a, AF: AddressFamily, S: Stride> std::iter::Iterator for
         }    
 }
 
-impl<'a, AF: AddressFamily> NodeMoreSpecificsPrefixIter<AF, Stride3> {
+impl<AF: AddressFamily> NodeMoreSpecificsPrefixIter<AF, Stride3> {
     pub fn wrap(self) -> SizedPrefixIter<AF> {
         SizedPrefixIter::<AF>::Stride3(self)
     }
 }
 
-impl<'a, AF: AddressFamily> NodeMoreSpecificsPrefixIter<AF, Stride4> {
+impl<AF: AddressFamily> NodeMoreSpecificsPrefixIter<AF, Stride4> {
     pub fn wrap(self) -> SizedPrefixIter<AF> {
         SizedPrefixIter::<AF>::Stride4(self)
     }
 }
 
-impl<'a, AF: AddressFamily> NodeMoreSpecificsPrefixIter<AF, Stride5> {
+impl<AF: AddressFamily> NodeMoreSpecificsPrefixIter<AF, Stride5> {
     pub fn wrap(self) -> SizedPrefixIter<AF> {
         SizedPrefixIter::Stride5(self)
     }

--- a/src/local_array/query.rs
+++ b/src/local_array/query.rs
@@ -1,6 +1,5 @@
 use crossbeam_epoch::{self as epoch};
 use epoch::Guard;
-use routecore::bgp::RecordSet;
 
 use crate::af::AddressFamily;
 use crate::local_array::store::atomic_types::{NodeBuckets, PrefixBuckets};

--- a/src/local_array/query.rs
+++ b/src/local_array/query.rs
@@ -109,7 +109,7 @@ where
         options: &MatchOptions,
         guard: &'a Guard,
     ) -> QueryResult<'a, M> {
-        // `non_recursive_retrieve_prefix_with_guard` return an exact match
+        // `non_recursive_retrieve_prefix_with_guard` returns an exact match
         // only, so no longest matching prefix!
         let mut stored_prefix = self
             .store
@@ -121,13 +121,9 @@ where
         // first lesser-specific with the greatest length, that's the Longest
         // matching prefix, but only if the user requested a longest match or
         // empty match.
-        let mut include_more_specifics = false;
-        let mut include_less_specifics = false;
         let match_type = match (&options.match_type, &stored_prefix) {
             // we found an exact match, we don't need to do anything.
             (_, Some(_pfx)) => {
-                include_more_specifics = options.include_more_specifics;
-                include_less_specifics = options.include_less_specifics;
                 MatchType::ExactMatch
             }
             // we didn't find an exact match, but the user requested it
@@ -137,22 +133,24 @@ where
                     .store
                     .less_specific_prefix_iter(search_pfx, guard)
                     .max_by(|p0, p1| p0.len.cmp(&p1.len));
-                include_more_specifics = options.include_more_specifics;
-                include_less_specifics = options.include_less_specifics;
                 if stored_prefix.is_some() {
                     MatchType::LongestMatch
                 } else {
                     MatchType::EmptyMatch
                 }
             }
-            // We got an empty match, but the user requested an exact match
-            (MatchType::ExactMatch, None) => MatchType::EmptyMatch,
+            // We got an empty match, but the user requested an exact match,
+            // even so, we're going to look for more and/or less specifics if
+            // the user asked for it.
+            (MatchType::ExactMatch, None) => { 
+                MatchType::EmptyMatch
+            },
         };
 
         QueryResult {
             prefix: stored_prefix.map(|p| p.prefix_into_pub()),
             prefix_meta: stored_prefix.map(|pfx| &pfx.meta),
-            less_specifics: if include_less_specifics {
+            less_specifics: if options.include_less_specifics {
                 Some(
                     self.store
                         .less_specific_prefix_iter(
@@ -165,15 +163,10 @@ where
                         )
                         .collect(),
                 )
-            } else if options.include_less_specifics {
-                Some(RecordSet {
-                    v4: vec![],
-                    v6: vec![],
-                })
             } else {
                 None
             },
-            more_specifics: if include_more_specifics {
+            more_specifics: if options.include_more_specifics {
                 Some(
                     self.store
                         .more_specific_prefix_iter_from(
@@ -189,14 +182,7 @@ where
                 )
                 // The user requested more specifics, but there aren't any, so we
                 // need to return an empty vec, not a None.
-            } else if options.include_more_specifics {
-                Some(RecordSet {
-                    v4: vec![],
-                    v6: vec![],
-                })
-            } else {
-                None
-            },
+            } else { None },
             match_type,
         }
     }

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -677,7 +677,6 @@ impl<
 // This implements the funky stats for a tree
 #[cfg(feature = "cli")]
 impl<
-        'a,
         AF: AddressFamily,
         M: Meta + MergeUpdate,
         NB: NodeBuckets<AF>,
@@ -758,38 +757,38 @@ impl<
             let n = (nodes_num / SCALE) as usize;
             let max_pfx = u128::overflowing_pow(2, stride_bits[1] as u32);
 
-            print!("{}-{}\t", stride_bits[0], stride_bits[1]);
+            write!(_f, "{}-{}\t", stride_bits[0], stride_bits[1])?;
 
             for _ in 0..n {
-                print!("{}", Colour::Blue.paint("█"));
+                write!(_f, "{}", Colour::Blue.paint("█"))?;
             }
 
-            print!(
+            write!(_f, 
                 "{}",
                 Colour::Blue.paint(
                     bars[((nodes_num % SCALE) / (SCALE / 7)) as usize]
                 ) //  = scale / 7
-            );
+            )?;
 
-            print!(
+            write!(_f, 
                 " {}/{} {:.2}%",
                 nodes_num,
                 max_pfx.0,
                 (nodes_num as f64 / max_pfx.0 as f64) * 100.0
-            );
-            print!("\n\t");
+            )?;
+            write!(_f, "\n\t")?;
 
             let n = (prefixes_num / SCALE) as usize;
             for _ in 0..n {
-                print!("{}", Colour::Green.paint("█"));
+                write!(_f, "{}", Colour::Green.paint("█"))?;
             }
 
-            print!(
+            write!(_f, 
                 "{}",
                 Colour::Green.paint(
                     bars[((nodes_num % SCALE) / (SCALE / 7)) as usize]
                 ) //  = scale / 7
-            );
+            )?;
 
             trace!(" {}", prefixes_num);
         }

--- a/src/local_vec/tree.rs
+++ b/src/local_vec/tree.rs
@@ -104,7 +104,7 @@ where
     pub store: Store,
 }
 
-impl<'a, Store> TreeBitMap<Store>
+impl<Store> TreeBitMap<Store>
 where
     Store: StorageBackend,
 {
@@ -460,34 +460,36 @@ where
 
 // This implements the funky stats for a tree
 #[cfg(feature = "cli")]
-impl<'a, Store: StorageBackend> std::fmt::Display for TreeBitMap<Store> {
+impl<Store: StorageBackend> std::fmt::Display for TreeBitMap<Store> {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let total_nodes = self.store.get_nodes_len();
 
-        println!("prefix vec size {}", self.store.get_prefixes_len());
-        println!("finished building tree...");
-        println!("{:?} nodes created", total_nodes);
-        println!(
+        writeln!(_f, "prefix vec size {}", self.store.get_prefixes_len())?;
+        writeln!(_f, "finished building tree...")?;
+        writeln!(_f, "{:?} nodes created", total_nodes)?;
+        writeln!(_f,
             "size of node: {} bytes",
             std::mem::size_of::<SizedStrideNode<u32, InMemNodeId>>()
-        );
-        println!(
+        )?;
+        writeln!(
+            _f,
             "memory used by nodes: {}kb",
             self.store.get_nodes_len()
                 * std::mem::size_of::<SizedStrideNode<u32, InMemNodeId>>()
                 / 1024
-        );
+        )?;
 
-        println!("stride division {:?}", self.strides);
+        writeln!(_f, "stride division {:?}", self.strides)?;
         for s in &self.stats {
-            println!("{:?}", s);
+            writeln!(_f, "{:?}", s)?;
         }
 
-        println!(
+        writeln!(
+            _f,
             "level\t[{}|{}] nodes occupied/max nodes percentage_max_nodes_occupied prefixes",
             Colour::Blue.paint("nodes"),
             Colour::Green.paint("prefixes")
-        );
+        )?;
         let bars = ["▏", "▎", "▍", "▌", "▋", "▊", "▉"];
         let mut stride_bits = [0, 0];
         const SCALE: u32 = 5500;
@@ -513,40 +515,43 @@ impl<'a, Store: StorageBackend> std::fmt::Display for TreeBitMap<Store> {
             let n = (nodes_num / SCALE) as usize;
             let max_pfx = u128::overflowing_pow(2, stride_bits[1] as u32);
 
-            print!("{}-{}\t", stride_bits[0], stride_bits[1]);
+            write!(_f, "{}-{}\t", stride_bits[0], stride_bits[1])?;
 
             for _ in 0..n {
-                print!("{}", Colour::Blue.paint("█"));
+                write!(_f, "{}", Colour::Blue.paint("█"))?;
             }
 
-            print!(
+            writeln!(
+                _f,
                 "{}",
                 Colour::Blue.paint(
                     bars[((nodes_num % SCALE) / (SCALE / 7)) as usize]
                 ) //  = scale / 7
-            );
+            )?;
 
-            print!(
+            writeln!(
+                _f,
                 " {}/{} {:.2}%",
                 nodes_num,
                 max_pfx.0,
                 (nodes_num as f64 / max_pfx.0 as f64) * 100.0
-            );
-            print!("\n\t");
+            )?;
+            write!(_f, "\n\t")?;
 
             let n = (prefixes_num / SCALE) as usize;
             for _ in 0..n {
-                print!("{}", Colour::Green.paint("█"));
+                write!(_f, "{}", Colour::Green.paint("█"))?;
             }
 
-            print!(
+            write!(
+                _f,
                 "{}",
                 Colour::Green.paint(
                     bars[((nodes_num % SCALE) / (SCALE / 7)) as usize]
                 ) //  = scale / 7
-            );
+            )?;
 
-            println!(" {}", prefixes_num);
+            writeln!(_f," {}", prefixes_num)?;
         }
         Ok(())
     }

--- a/src/rotonda_store.rs
+++ b/src/rotonda_store.rs
@@ -65,10 +65,23 @@ impl<'a> std::fmt::Debug for Strides<'a> {
 
 //------------ MatchOptions / MatchType -------------------------------------
 
+/// Options for the `match_prefix` method
+/// 
+/// The `MatchOptions` struct is used to specify the options for the 
+/// `match_prefix` method on the store.
+/// 
+/// Note that the `match_type` field may be different from the actual
+/// `MatchType` returned from the result. 
+/// 
+/// See [MultiThreadedStore::match_prefix] for more details.
 pub struct MatchOptions {
+    /// The requested [MatchType]
     pub match_type: MatchType,
+    /// unused
     pub include_all_records: bool,
+    /// whether to include all less-specific records in the query result
     pub include_less_specifics: bool,
+    // whether to include all more-specific records in the query result
     pub include_more_specifics: bool,
 }
 
@@ -274,12 +287,26 @@ impl<'a, M: routecore::record::Meta> std::fmt::Display
 
 //------------- QueryResult -------------------------------------------------
 
+/// The type that is returned by a query.
+/// 
+/// This is the result type of a query. It contains the prefix record that was
+/// found in the store, as well as less- or more-specifics as requested.
+/// 
+/// See [MultiThreadedStore::match_prefix] for more details.
+
+
+
 #[derive(Clone, Debug)]
 pub struct QueryResult<'a, M: routecore::record::Meta> {
+    /// The match type of the resulting prefix
     pub match_type: MatchType,
+    /// The resulting prefix record
     pub prefix: Option<Prefix>,
+    /// The meta data associated with the resulting prefix record
     pub prefix_meta: Option<&'a M>,
+    /// The less-specifics of the resulting prefix together with their meta data
     pub less_specifics: Option<RecordSet<'a, M>>,
+    /// The more-specifics of the resulting prefix together with their meta data
     pub more_specifics: Option<RecordSet<'a, M>>,
 }
 

--- a/src/rotonda_store.rs
+++ b/src/rotonda_store.rs
@@ -77,11 +77,11 @@ impl<'a> std::fmt::Debug for Strides<'a> {
 pub struct MatchOptions {
     /// The requested [MatchType]
     pub match_type: MatchType,
-    /// unused
+    /// Unused
     pub include_all_records: bool,
-    /// whether to include all less-specific records in the query result
+    /// Whether to include all less-specific records in the query result
     pub include_less_specifics: bool,
-    // whether to include all more-specific records in the query result
+    /// Whether to include all more-specific records in the query result
     pub include_more_specifics: bool,
 }
 
@@ -290,9 +290,8 @@ impl<'a, M: routecore::record::Meta> std::fmt::Display
 /// The type that is returned by a query.
 /// 
 /// This is the result type of a query. It contains the prefix record that was
-/// found in the store, as well as less- or more-specifics as requested.
-/// 
-/// See [MultiThreadedStore::match_prefix] for more details.
+/// found in the store, as well as less- or more-specifics as requested. See
+/// [MultiThreadedStore::match_prefix] for more details.
 
 
 

--- a/tests/more-specifics.rs
+++ b/tests/more-specifics.rs
@@ -107,7 +107,12 @@ mod tests {
                     23,
                 ),
                 None,
-                Vec::<usize>::new(),
+                // These are the indexes to pfxs.2 vec.
+                // These are all supposed to show up in the result.
+                vec![
+                    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+                    17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+                ],
             ),
             (
                 &Prefix::new(


### PR DESCRIPTION
A query with match_type `ExactMatch` returns no less or more specifics if there is no exactly matching prefix. We are changing this behavior to include the less and/or more specifics (if the user specified it in the `MatchOptions`) even if the query itself returns no matching prefix (`EmptyMatch`).

This solves https://github.com/NLnetLabs/rotonda-runtime/issues/79