### PR TITLE
Switch to stock generic-messages branch of routecore.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ env_logger = {version = "0.9.0", optional = true}
 log = "0.4.14"
 rotonda-macros = "0.2.0-pre.1"
 #routecore = "0.2.0-pre.1"
-#routecore = { version = "0.3.0-dev", features = ["bgp"], git = "https://github.com/NLnetLabs/routecore.git", branch = "generic-messages" }
-routecore = { version = "0.3.0-dev", features = ["bgp"], git = "https://github.com/NLnetLabs/routecore.git", branch = "extensions-to-generic-messages-used-by-rotonda-runtime" }
+routecore = { version = "0.3.0-dev", features = ["bgp"], git = "https://github.com/NLnetLabs/routecore.git", branch = "generic-messages" }
 rustyline = {version = "8.0.0", optional = true}
 
 [build-dependencies]


### PR DESCRIPTION
Needed by https://github.com/NLnetLabs/rotonda-runtime/pull/86.