### PR TITLE
Release 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["routing", "bgp"]
 license = "BSD-3-Clause"
 name = "rotonda-store"
 repository = "https://github.com/NLnetLabs/rotonda-store/"
-version = "0.3.0-rc0"
+version = "0.3.0"
 rust-version = "1.71"
 
 [dependencies]
@@ -19,7 +19,7 @@ crossbeam-utils = "^0.8"
 log             = "^0.4"
 rotonda-macros  = { version = "^0.3" }
 
-routecore   = { version = "0.4.0-rc0", features = ["bgp", "bmp", "serde"] }
+routecore   = { version = "0.4.0", features = ["bgp", "bmp", "serde"] }
 ansi_term   = { version = "^0.12", optional = true }
 rustyline   = { version = "^13", optional = true }
 csv         = { version = "^1", optional = true }

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## 0.3.0-rc0
+## 0.3.0
 
-Released 2024-01-10.
+Released 2024-01-18.
 
 Breaking changes
 

--- a/src/af.rs
+++ b/src/af.rs
@@ -108,7 +108,7 @@ impl AddressFamily for IPv4 {
     /// Will panic if there is insufficient space to add the given nibble,
     /// i.e. if `len + nibble_len >= 32`.
     ///
-    /// ```should_panic
+    /// ```
     /// # use rotonda_store::IPv4;
     /// # use rotonda_store::AddressFamily;
     /// let prefix = 0b10101010_00000000_00000000_00000100_u32; // 30-bit prefix
@@ -194,7 +194,7 @@ impl AddressFamily for IPv6 {
     /// Will panic if there is insufficient space to add the given nibble,
     /// i.e. if `len + nibble_len >= 128`.
     ///
-    /// ```should_panic
+    /// ```
     /// # use rotonda_store::IPv6;
     /// # use rotonda_store::AddressFamily;
     /// let prefix = 0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFF0000u128; // 112-bit prefix


### PR DESCRIPTION
Changes from 0.2.0-rc0
- removed two `should_panic` in cargo doc comments. This actually only happens in debug mode, and we are testing for release.