### PR TITLE
Indexed multi map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ ansi_term   = { version = "^0.12", optional = true }
 rustyline   = { version = "^13", optional = true }
 csv         = { version = "^1", optional = true }
 roaring = "0.10.3"
+flurry = "0.5.1"
 
 [dev-dependencies]
 rand        = "^0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ arc-swap        = "^1.6"
 crossbeam-epoch = "^0.9"
 crossbeam-utils = "^0.8"
 log             = "^0.4"
-rotonda-macros  = { git = "https://github.com/NLnetLabs/rotonda-macros", branch = "indexed-multi-map" }
-# rotonda-macros = { path = "../rotonda-macros" }
+# rotonda-macros  = { git = "https://github.com/NLnetLabs/rotonda-macros", branch = "indexed-multi-map" }
+rotonda-macros = { path = "../rotonda-macros" }
 
 inetnum     = { version = "0.1.0", features = ["arbitrary", "serde"] }
 ansi_term   = { version = "^0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ arc-swap        = "^1.6"
 crossbeam-epoch = "^0.9"
 crossbeam-utils = "^0.8"
 log             = "^0.4"
-# rotonda-macros  = { version = "^0.3.1" }
-rotonda-macros = { path = "../rotonda-macros" }
+rotonda-macros  = { git = "https://github.com/NLnetLabs/rotonda-macros", branch = "indexed-multi-map" }
+# rotonda-macros = { path = "../rotonda-macros" }
 
 inetnum     = { version = "0.1.0", features = ["arbitrary", "serde"] }
 ansi_term   = { version = "^0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,14 @@ arc-swap        = "^1.6"
 crossbeam-epoch = "^0.9"
 crossbeam-utils = "^0.8"
 log             = "^0.4"
-rotonda-macros  = { version = "^0.3.1" }
+# rotonda-macros  = { version = "^0.3.1" }
+rotonda-macros = { path = "../rotonda-macros" }
 
 inetnum     = { version = "0.1.0", features = ["arbitrary", "serde"] }
 ansi_term   = { version = "^0.12", optional = true }
 rustyline   = { version = "^13", optional = true }
 csv         = { version = "^1", optional = true }
+roaring = "0.10.3"
 
 [dev-dependencies]
 rand        = "^0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ arc-swap        = "^1.6"
 crossbeam-epoch = "^0.9"
 crossbeam-utils = "^0.8"
 log             = "^0.4"
-# rotonda-macros  = { git = "https://github.com/NLnetLabs/rotonda-macros", branch = "indexed-multi-map" }
-rotonda-macros = { path = "../rotonda-macros" }
+rotonda-macros  = { git = "https://github.com/NLnetLabs/rotonda-macros", branch = "indexed-multi-map" }
+# rotonda-macros = { path = "../rotonda-macros" }
 
 inetnum     = { version = "0.1.0", features = ["arbitrary", "serde"] }
 ansi_term   = { version = "^0.12", optional = true }

--- a/examples/exact_matches.rs
+++ b/examples/exact_matches.rs
@@ -340,9 +340,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &spfx.unwrap(),
             &MatchOptions {
                 match_type: MatchType::ExactMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: false,
                 include_more_specifics: false,
+                mui: None
             },
             guard
         );

--- a/examples/exact_matches.rs
+++ b/examples/exact_matches.rs
@@ -258,7 +258,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for pfx in pfxs.into_iter() {
         println!("insert {}", pfx?);
         // let p : rotonda_store::Prefix<u32, PrefixAs> = pfx.into();
-        tree_bitmap.insert(&pfx.unwrap(), 0, NoMeta::Empty)?;
+        tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
     }
     println!("------ end of inserts\n");
     // println!(

--- a/examples/exact_matches.rs
+++ b/examples/exact_matches.rs
@@ -258,7 +258,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for pfx in pfxs.into_iter() {
         println!("insert {}", pfx?);
         // let p : rotonda_store::Prefix<u32, PrefixAs> = pfx.into();
-        tree_bitmap.insert(&pfx.unwrap(), NoMeta::Empty)?;
+        tree_bitmap.insert(&pfx.unwrap(), 0, NoMeta::Empty)?;
     }
     println!("------ end of inserts\n");
     // println!(

--- a/examples/exact_matches.rs
+++ b/examples/exact_matches.rs
@@ -258,7 +258,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for pfx in pfxs.into_iter() {
         println!("insert {}", pfx?);
         // let p : rotonda_store::Prefix<u32, PrefixAs> = pfx.into();
-        tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
+        tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::Active, NoMeta::Empty), None)?;
     }
     println!("------ end of inserts\n");
     // println!(

--- a/examples/exact_matches_single.rs
+++ b/examples/exact_matches_single.rs
@@ -260,7 +260,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for pfx in pfxs.into_iter() {
         println!("insert {}", pfx?);
         // let p : rotonda_store::Prefix<u32, PrefixAs> = pfx.into();
-        tree_bitmap.insert(&pfx.unwrap(), NoMeta::Empty, None)?;
+        tree_bitmap.insert(&pfx.unwrap(), NoMeta::Empty)?;
     }
     println!("------ end of inserts\n");
     // println!(

--- a/examples/exact_matches_single.rs
+++ b/examples/exact_matches_single.rs
@@ -342,9 +342,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &spfx.unwrap(),
             &MatchOptions {
                 match_type: MatchType::ExactMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: false,
                 include_more_specifics: false,
+                mui: None
             },
         );
         println!("exact match: {:?}", s_spfx);

--- a/examples/full_table_multiple_trees_json.rs
+++ b/examples/full_table_multiple_trees_json.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             let asn: u32 = record[2].parse().unwrap();
             let pfx = PrefixRecord::<PrefixAs>::new(
                 Prefix::new(net.into(), len)?,
-                PrefixAs(asn),
+                vec![Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(asn))],
             );
             pfxs.push(pfx);
         }
@@ -45,19 +45,19 @@ fn main() -> Result<(), Box<dyn Error>> {
     for strides in strides_vec.iter().enumerate() {
         println!("[");
         for n in 1..6 {
-            let mut pfxs: Vec<PrefixRecord<PrefixAs>> = vec![];
+            let mut rec_vec: Vec<PrefixRecord<PrefixAs>> = vec![];
             let tree_bitmap = MyStore::<PrefixAs>::new()?;
 
-            if let Err(err) = load_prefixes(&mut pfxs) {
+            if let Err(err) = load_prefixes(&mut rec_vec) {
                 println!("error running example: {}", err);
                 process::exit(1);
             }
             // println!("finished loading {} prefixes...", pfxs.len());
             let start = std::time::Instant::now();
 
-            let inserts_num = pfxs.len();
-            for pfx in pfxs.into_iter() {
-                tree_bitmap.insert(&pfx.prefix, 0, pfx.meta)?;
+            let inserts_num = rec_vec.len();
+            for rec in rec_vec.into_iter() {
+                tree_bitmap.insert(&rec.prefix, rec.meta[0].clone())?;
             }
             let ready = std::time::Instant::now();
             let dur_insert_nanos =

--- a/examples/full_table_multiple_trees_json.rs
+++ b/examples/full_table_multiple_trees_json.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let inserts_num = pfxs.len();
             for pfx in pfxs.into_iter() {
-                tree_bitmap.insert(&pfx.prefix, pfx.meta)?;
+                tree_bitmap.insert(&pfx.prefix, 0, pfx.meta)?;
             }
             let ready = std::time::Instant::now();
             let dur_insert_nanos =

--- a/examples/full_table_multiple_trees_json.rs
+++ b/examples/full_table_multiple_trees_json.rs
@@ -82,9 +82,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 &pfx,
                                 &MatchOptions {
                                     match_type: MatchType::LongestMatch,
-                                    include_all_records: false,
+                                    include_withdrawn: false,
                                     include_less_specifics: false,
                                     include_more_specifics: false,
+                                    mui: None
                                 },
                                 guard
                             );

--- a/examples/full_table_multiple_trees_json.rs
+++ b/examples/full_table_multiple_trees_json.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             let asn: u32 = record[2].parse().unwrap();
             let pfx = PrefixRecord::<PrefixAs>::new(
                 Prefix::new(net.into(), len)?,
-                vec![Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(asn))],
+                vec![Record::new(0, 0, RouteStatus::Active, PrefixAs(asn))],
             );
             pfxs.push(pfx);
         }
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             let inserts_num = rec_vec.len();
             for rec in rec_vec.into_iter() {
-                tree_bitmap.insert(&rec.prefix, rec.meta[0].clone())?;
+                tree_bitmap.insert(&rec.prefix, rec.meta[0].clone(), None)?;
             }
             let ready = std::time::Instant::now();
             let dur_insert_nanos =

--- a/examples/more_specifics.rs
+++ b/examples/more_specifics.rs
@@ -215,7 +215,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for pfx in pfxs.into_iter() {
         // println!("insert {:?}", pfx);
         let p: Prefix = pfx.unwrap();
-        tree_bitmap.insert(&p, Record::new(0,0, RouteStatus::InConvergence, PrefixAs(666)))?;
+        tree_bitmap.insert(&p, Record::new(0,0, RouteStatus::Active, PrefixAs(666)), None)?;
     }
     println!("------ end of inserts\n");
     // println!(

--- a/examples/more_specifics.rs
+++ b/examples/more_specifics.rs
@@ -281,9 +281,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &spfx.unwrap(),
             &MatchOptions {
                 match_type: MatchType::ExactMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: true,
+                mui: None
             },
             guard
         );

--- a/examples/more_specifics.rs
+++ b/examples/more_specifics.rs
@@ -215,7 +215,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for pfx in pfxs.into_iter() {
         // println!("insert {:?}", pfx);
         let p: Prefix = pfx.unwrap();
-        tree_bitmap.insert(&p, PrefixAs(666))?;
+        tree_bitmap.insert(&p, 0, PrefixAs(666))?;
     }
     println!("------ end of inserts\n");
     // println!(

--- a/examples/more_specifics.rs
+++ b/examples/more_specifics.rs
@@ -215,7 +215,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for pfx in pfxs.into_iter() {
         // println!("insert {:?}", pfx);
         let p: Prefix = pfx.unwrap();
-        tree_bitmap.insert(&p, 0, PrefixAs(666))?;
+        tree_bitmap.insert(&p, Record::new(0,0, RouteStatus::InConvergence, PrefixAs(666)))?;
     }
     println!("------ end of inserts\n");
     // println!(

--- a/examples/multi_no_thread.rs
+++ b/examples/multi_no_thread.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         x += 1;
         // print!("{}-", i);
-        match tree_bitmap.insert(&pfx.unwrap(), 0, PrefixAs(x % 1000)) {
+        match tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(x % 1000))) {
             Ok(_) => {}
             Err(e) => {
                 println!("{}", e);

--- a/examples/multi_no_thread.rs
+++ b/examples/multi_no_thread.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         x += 1;
         // print!("{}-", i);
-        match tree_bitmap.insert(&pfx.unwrap(), PrefixAs(x % 1000)) {
+        match tree_bitmap.insert(&pfx.unwrap(), 0, PrefixAs(x % 1000)) {
             Ok(_) => {}
             Err(e) => {
                 println!("{}", e);

--- a/examples/multi_no_thread.rs
+++ b/examples/multi_no_thread.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         x += 1;
         // print!("{}-", i);
-        match tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(x % 1000))) {
+        match tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::Active, PrefixAs(x % 1000)), None) {
             Ok(_) => {}
             Err(e) => {
                 println!("{}", e);

--- a/examples/multi_no_thread.rs
+++ b/examples/multi_no_thread.rs
@@ -41,9 +41,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &pfx.unwrap(),
         &MatchOptions {
             match_type: rotonda_store::MatchType::ExactMatch,
-            include_all_records: true,
+            include_withdrawn: true,
             include_less_specifics: true,
             include_more_specifics: true,
+            mui: None
         },
         guard,
     );

--- a/examples/multi_single_thread.rs
+++ b/examples/multi_single_thread.rs
@@ -43,7 +43,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // x += 1;
                 // print!("{}-", i);
                 let asn: u32 = rng.gen();
-                match tree_bitmap.insert(&pfx.unwrap(), 0, PrefixAs(asn)) {
+                match tree_bitmap.insert(
+                    &pfx.unwrap(),
+                    Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(asn))
+                ) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/examples/multi_single_thread.rs
+++ b/examples/multi_single_thread.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // x += 1;
                 // print!("{}-", i);
                 let asn: u32 = rng.gen();
-                match tree_bitmap.insert(&pfx.unwrap(), PrefixAs(asn)) {
+                match tree_bitmap.insert(&pfx.unwrap(), 0, PrefixAs(asn)) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/examples/multi_single_thread.rs
+++ b/examples/multi_single_thread.rs
@@ -45,7 +45,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let asn: u32 = rng.gen();
                 match tree_bitmap.insert(
                     &pfx.unwrap(),
-                    Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(asn))
+                    Record::new(0, 0, RouteStatus::Active, PrefixAs(asn)),
+                    None
                 ) {
                     Ok(_) => {}
                     Err(e) => {

--- a/examples/multi_thread_1.rs
+++ b/examples/multi_thread_1.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("insert {}", pfx.unwrap());
 
                     match tree_bitmap
-                        .insert(&pfx.unwrap(), NoMeta::Empty)
+                        .insert(&pfx.unwrap(), 0, NoMeta::Empty)
                     {
                         Ok(_) => {}
                         Err(e) => {

--- a/examples/multi_thread_1.rs
+++ b/examples/multi_thread_1.rs
@@ -18,8 +18,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("insert {}", pfx.unwrap());
 
                     match tree_bitmap
-                        .insert(&pfx.unwrap(), 0, NoMeta::Empty)
-                    {
+                        .insert(&pfx.unwrap(), 
+                        Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty)
+                    ) {
                         Ok(_) => {}
                         Err(e) => {
                             println!("{}", e);

--- a/examples/multi_thread_1.rs
+++ b/examples/multi_thread_1.rs
@@ -18,8 +18,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("insert {}", pfx.unwrap());
 
                     match tree_bitmap
-                        .insert(&pfx.unwrap(), 
-                        Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty)
+                        .insert(
+                            &pfx.unwrap(), 
+                            Record::new(0, 0, RouteStatus::Active, NoMeta::Empty),
+                            None
                     ) {
                         Ok(_) => {}
                         Err(e) => {

--- a/examples/multi_thread_1.rs
+++ b/examples/multi_thread_1.rs
@@ -44,9 +44,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &spfx.unwrap(),
             &MatchOptions {
                 match_type: rotonda_store::MatchType::ExactMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: true,
+                mui: None
             },
             guard,
         );

--- a/examples/multi_thread_2.rs
+++ b/examples/multi_thread_2.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     thread::park();
                 }
 
-                match tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(i as u32))) {
+                match tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::Active, PrefixAs(i as u32)), None) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/examples/multi_thread_2.rs
+++ b/examples/multi_thread_2.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     thread::park();
                 }
 
-                match tree_bitmap.insert(&pfx.unwrap(), PrefixAs(i as u32)) {
+                match tree_bitmap.insert(&pfx.unwrap(), 0, PrefixAs(i as u32)) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/examples/multi_thread_2.rs
+++ b/examples/multi_thread_2.rs
@@ -58,9 +58,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &pfx.unwrap(),
         &MatchOptions {
             match_type: rotonda_store::MatchType::ExactMatch,
-            include_all_records: true,
+            include_withdrawn: true,
             include_less_specifics: true,
             include_more_specifics: true,
+            mui: None
         },
         guard,
     );

--- a/examples/multi_thread_2.rs
+++ b/examples/multi_thread_2.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     thread::park();
                 }
 
-                match tree_bitmap.insert(&pfx.unwrap(), 0, PrefixAs(i as u32)) {
+                match tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(i as u32))) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/examples/multi_thread_3.rs
+++ b/examples/multi_thread_3.rs
@@ -38,11 +38,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     x += 1;
                     // print!("{}-", i);
                     match tree_bitmap
-                        .insert(&pfx.unwrap(), 0, PrefixAs(i as u32))
+                        .insert(&pfx.unwrap(), Record::new(0,0, RouteStatus::InConvergence, PrefixAs(i as u32)))
                     {
                         Ok(metrics) => {
-                            if metrics.1 > 0  {
-                                println!("{} {} {:?} retry count {},", std::thread::current().name().unwrap(), metrics.0, pfx, metrics.1);
+                            if metrics.cas_count > 0  {
+                                println!("{} {:?} {:?} retry count {},", std::thread::current().name().unwrap(), metrics, pfx, metrics.cas_count);
                             }
                         }
                         Err(e) => {

--- a/examples/multi_thread_3.rs
+++ b/examples/multi_thread_3.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     x += 1;
                     // print!("{}-", i);
                     match tree_bitmap
-                        .insert(&pfx.unwrap(), PrefixAs(i as u32))
+                        .insert(&pfx.unwrap(), 0, PrefixAs(i as u32))
                     {
                         Ok(metrics) => {
                             if metrics.1 > 0  {

--- a/examples/multi_thread_3.rs
+++ b/examples/multi_thread_3.rs
@@ -38,7 +38,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     x += 1;
                     // print!("{}-", i);
                     match tree_bitmap
-                        .insert(&pfx.unwrap(), Record::new(0,0, RouteStatus::InConvergence, PrefixAs(i as u32)))
+                        .insert(
+                            &pfx.unwrap(),
+                            Record::new(0,0, RouteStatus::Active, PrefixAs(i as u32)),
+                            None
+                        )
                     {
                         Ok(metrics) => {
                             if metrics.cas_count > 0  {

--- a/examples/multi_thread_3.rs
+++ b/examples/multi_thread_3.rs
@@ -77,9 +77,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &pfx.unwrap(),
         &MatchOptions {
             match_type: rotonda_store::MatchType::ExactMatch,
-            include_all_records: true,
+            include_withdrawn: true,
             include_less_specifics: true,
             include_more_specifics: true,
+            mui: None
         },
         guard,
     );

--- a/examples/multi_thread_4.rs
+++ b/examples/multi_thread_4.rs
@@ -74,12 +74,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         // print!("{}-", i);
                         match tree_bitmap.insert(
                             &pfx.unwrap(),
-                            0,
-                            ComplexPrefixAs([i as u32].to_vec()),
+                            Record::new(
+                                0,
+                                0,
+                                RouteStatus::InConvergence,
+                                ComplexPrefixAs([i as u32].to_vec()),
+                            )
                         ) {
                             Ok(metrics) => {
-                                if metrics.1 > 0 {
-                                    eprintln!("{} {} {:?} retry count: {},", std::thread::current().name().unwrap(), metrics.0, pfx, metrics.1);
+                                if metrics.cas_count > 0 {
+                                    eprintln!("{} {} {:?} retry count: {},", std::thread::current().name().unwrap(), metrics.prefix_new, pfx, metrics.cas_count);
                                 }
                             }
                             Err(e) => {

--- a/examples/multi_thread_4.rs
+++ b/examples/multi_thread_4.rs
@@ -74,6 +74,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         // print!("{}-", i);
                         match tree_bitmap.insert(
                             &pfx.unwrap(),
+                            0,
                             ComplexPrefixAs([i as u32].to_vec()),
                         ) {
                             Ok(metrics) => {

--- a/examples/multi_thread_4.rs
+++ b/examples/multi_thread_4.rs
@@ -1,4 +1,5 @@
 use log::trace;
+use routecore::bgp::path_selection::{OrdRoute, Rfc4271};
 use std::time::Duration;
 use std::{sync::Arc, thread};
 
@@ -6,7 +7,7 @@ use std::{sync::Arc, thread};
 use rotonda_store::prelude::*;
 use rotonda_store::prelude::multi::*;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ComplexPrefixAs(pub Vec<u32>);
 
 // impl MergeUpdate for ComplexPrefixAs {
@@ -35,6 +36,15 @@ pub struct ComplexPrefixAs(pub Vec<u32>);
 //         Ok((ComplexPrefixAs(new_meta), ()))
 //     }
 // }
+
+impl Meta for ComplexPrefixAs {
+    type Orderable<'a> = ComplexPrefixAs;
+    type TBI = ();
+    
+    fn as_orderable(&self, _tbi: Self::TBI) -> ComplexPrefixAs {
+        self.clone()
+    }
+}
 
 impl std::fmt::Display for ComplexPrefixAs {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/examples/multi_thread_4.rs
+++ b/examples/multi_thread_4.rs
@@ -9,32 +9,32 @@ use rotonda_store::prelude::multi::*;
 #[derive(Debug, Clone)]
 pub struct ComplexPrefixAs(pub Vec<u32>);
 
-impl MergeUpdate for ComplexPrefixAs {
-    type UserDataIn = ();
-    type UserDataOut = ();
+// impl MergeUpdate for ComplexPrefixAs {
+//     type UserDataIn = ();
+//     type UserDataOut = ();
 
-    fn merge_update(
-        &mut self,
-        update_record: ComplexPrefixAs,
-        _: Option<&Self::UserDataIn>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        self.0 = update_record.0;
-        Ok(())
-    }
+//     fn merge_update(
+//         &mut self,
+//         update_record: ComplexPrefixAs,
+//         _: Option<&Self::UserDataIn>,
+//     ) -> Result<(), Box<dyn std::error::Error>> {
+//         self.0 = update_record.0;
+//         Ok(())
+//     }
 
-    fn clone_merge_update(
-        &self,
-        update_meta: &Self,
-        _: Option<&Self::UserDataIn>,
-    ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
-    where
-        Self: std::marker::Sized,
-    {
-        let mut new_meta = update_meta.0.clone();
-        new_meta.push(self.0[0]);
-        Ok((ComplexPrefixAs(new_meta), ()))
-    }
-}
+//     fn clone_merge_update(
+//         &self,
+//         update_meta: &Self,
+//         _: Option<&Self::UserDataIn>,
+//     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
+//     where
+//         Self: std::marker::Sized,
+//     {
+//         let mut new_meta = update_meta.0.clone();
+//         new_meta.push(self.0[0]);
+//         Ok((ComplexPrefixAs(new_meta), ()))
+//     }
+// }
 
 impl std::fmt::Display for ComplexPrefixAs {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/examples/multi_thread_4.rs
+++ b/examples/multi_thread_4.rs
@@ -124,9 +124,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &pfx.unwrap(),
         &MatchOptions {
             match_type: rotonda_store::MatchType::ExactMatch,
-            include_all_records: true,
+            include_withdrawn: true,
             include_less_specifics: true,
             include_more_specifics: true,
+            mui: None
         },
         guard,
     );

--- a/examples/multi_thread_4.rs
+++ b/examples/multi_thread_4.rs
@@ -77,9 +77,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             Record::new(
                                 0,
                                 0,
-                                RouteStatus::InConvergence,
+                                RouteStatus::Active,
                                 ComplexPrefixAs([i as u32].to_vec()),
-                            )
+                            ),
+                            None
                         ) {
                             Ok(metrics) => {
                                 if metrics.cas_count > 0 {

--- a/examples/multi_thread_multi_prefix.rs
+++ b/examples/multi_thread_multi_prefix.rs
@@ -46,12 +46,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let guard = &crossbeam_epoch::pin();
                         while x < 100 {
                             let asn = PrefixAs(rng.gen());
-                            match tree_bitmap.insert(&pfx, 0, asn) {
+                            match tree_bitmap.insert(&pfx, Record::new(0, 0, RouteStatus::InConvergence, asn)) {
                                 Ok(metrics) => {
-                                    if let Upsert::Insert = metrics.0 {
+                                    if metrics.prefix_new {
                                         println!(
                                             "thread {} won: {} with value {}",
-                                            i, metrics.0, asn
+                                            i, metrics.prefix_new, asn
                                         );
                                     }
                                 }

--- a/examples/multi_thread_multi_prefix.rs
+++ b/examples/multi_thread_multi_prefix.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let guard = &crossbeam_epoch::pin();
                         while x < 100 {
                             let asn = PrefixAs(rng.gen());
-                            match tree_bitmap.insert(&pfx, asn) {
+                            match tree_bitmap.insert(&pfx, 0, asn) {
                                 Ok(metrics) => {
                                     if let Upsert::Insert = metrics.0 {
                                         println!(

--- a/examples/multi_thread_multi_prefix.rs
+++ b/examples/multi_thread_multi_prefix.rs
@@ -67,9 +67,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 &pfx,
                                 &MatchOptions {
                                     match_type: rotonda_store::MatchType::ExactMatch,
-                                    include_all_records: true,
+                                    include_withdrawn: true,
                                     include_less_specifics: true,
                                     include_more_specifics: true,
+                                    mui: None
                                 },
                                 guard,
                             ).prefix_meta;

--- a/examples/multi_thread_multi_prefix.rs
+++ b/examples/multi_thread_multi_prefix.rs
@@ -46,7 +46,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let guard = &crossbeam_epoch::pin();
                         while x < 100 {
                             let asn = PrefixAs(rng.gen());
-                            match tree_bitmap.insert(&pfx, Record::new(0, 0, RouteStatus::InConvergence, asn)) {
+                            match tree_bitmap.insert(
+                                &pfx,
+                                Record::new(0, 0, RouteStatus::Active, asn),
+                                None
+                            ) {
                                 Ok(metrics) => {
                                     if metrics.prefix_new {
                                         println!(

--- a/examples/multi_thread_single_prefix.rs
+++ b/examples/multi_thread_single_prefix.rs
@@ -42,7 +42,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let guard = &crossbeam_epoch::pin();
                         while x < 10_000 {
                             let asn = PrefixAs(rng.gen());
-                            match tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, asn)) {
+                            match tree_bitmap.insert(
+                                &pfx.unwrap(),
+                                Record::new(0, 0, RouteStatus::Active, asn),
+                                None
+                            ) {
                                 Ok(metrics) => {
                                     if metrics.prefix_new {
                                         println!(

--- a/examples/multi_thread_single_prefix.rs
+++ b/examples/multi_thread_single_prefix.rs
@@ -42,12 +42,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let guard = &crossbeam_epoch::pin();
                         while x < 10_000 {
                             let asn = PrefixAs(rng.gen());
-                            match tree_bitmap.insert(&pfx.unwrap(), 0, asn) {
+                            match tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, asn)) {
                                 Ok(metrics) => {
-                                    if let Upsert::Insert = metrics.0 {
+                                    if metrics.prefix_new {
                                         println!(
                                             "thread {} won: {} with value {}",
-                                            i, metrics.0, asn
+                                            i, metrics.prefix_new, asn
                                         );
                                     }
                                 }

--- a/examples/multi_thread_single_prefix.rs
+++ b/examples/multi_thread_single_prefix.rs
@@ -63,9 +63,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         &pfx.unwrap(),
                         &MatchOptions {
                             match_type: rotonda_store::MatchType::ExactMatch,
-                            include_all_records: true,
+                            include_withdrawn: true,
                             include_less_specifics: true,
                             include_more_specifics: true,
+                            mui: None
                         },
                         guard,
                     ).prefix_meta;

--- a/examples/multi_thread_single_prefix.rs
+++ b/examples/multi_thread_single_prefix.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let guard = &crossbeam_epoch::pin();
                         while x < 10_000 {
                             let asn = PrefixAs(rng.gen());
-                            match tree_bitmap.insert(&pfx.unwrap(), asn) {
+                            match tree_bitmap.insert(&pfx.unwrap(), 0, asn) {
                                 Ok(metrics) => {
                                     if let Upsert::Insert = metrics.0 {
                                         println!(

--- a/examples/numbers_treebitmap.rs
+++ b/examples/numbers_treebitmap.rs
@@ -2,6 +2,7 @@ use rotonda_store::meta_examples::PrefixAs;
 use rotonda_store::prelude::*;
 use rotonda_store::prelude::multi::*;
 
+use std::sync::atomic::Ordering;
 use std::env;
 use std::error::Error;
 use std::ffi::OsString;

--- a/examples/numbers_treebitmap.rs
+++ b/examples/numbers_treebitmap.rs
@@ -65,7 +65,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
 
         for pfx in pfxs.into_iter() {
-            tree_bitmap.insert(&pfx.prefix, pfx.meta)?;
+            tree_bitmap.insert(&pfx.prefix, 0, pfx.meta)?;
         }
         
         #[cfg(feature = "cli")]

--- a/examples/numbers_treebitmap.rs
+++ b/examples/numbers_treebitmap.rs
@@ -43,7 +43,7 @@ fn load_prefixes(
         let asn: u32 = record[2].parse().unwrap();
         let pfx = PrefixRecord::<PrefixAs>::new(
             Prefix::new(net, len)?,
-            vec![Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(asn))],
+            vec![Record::new(0, 0, RouteStatus::Active, PrefixAs(asn))],
         );
         pfxs.push(pfx);
         // trie.insert(&pfx);
@@ -65,7 +65,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
 
         for pfx in pfxs.into_iter() {
-            tree_bitmap.insert(&pfx.prefix, pfx.meta[0].clone())?;
+            tree_bitmap.insert(
+                &pfx.prefix, pfx.meta[0].clone(), None
+            )?;
         }
         
         #[cfg(feature = "cli")]

--- a/examples/numbers_treebitmap.rs
+++ b/examples/numbers_treebitmap.rs
@@ -43,7 +43,7 @@ fn load_prefixes(
         let asn: u32 = record[2].parse().unwrap();
         let pfx = PrefixRecord::<PrefixAs>::new(
             Prefix::new(net, len)?,
-            PrefixAs(asn),
+            vec![Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(asn))],
         );
         pfxs.push(pfx);
         // trie.insert(&pfx);
@@ -65,7 +65,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
 
         for pfx in pfxs.into_iter() {
-            tree_bitmap.insert(&pfx.prefix, 0, pfx.meta)?;
+            tree_bitmap.insert(&pfx.prefix, pfx.meta[0].clone())?;
         }
         
         #[cfg(feature = "cli")]

--- a/examples/real_single_thread_24.rs
+++ b/examples/real_single_thread_24.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 print!("{}-", pfx_int);
                 let asn: u32 = rng.gen();
-                match tree_bitmap.insert(&pfx.unwrap(), PrefixAs(asn), None) {
+                match tree_bitmap.insert(&pfx.unwrap(), PrefixAs(asn)) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/examples/single_thread_24.rs
+++ b/examples/single_thread_24.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // x += 1;
                 // print!("{}-", i);
                 let asn: u32 = rng.gen();
-                match tree_bitmap.insert(&pfx.unwrap(), PrefixAs(asn)) {
+                match tree_bitmap.insert(&pfx.unwrap(), 0, PrefixAs(asn)) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/examples/single_thread_24.rs
+++ b/examples/single_thread_24.rs
@@ -45,7 +45,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // x += 1;
                 // print!("{}-", i);
                 let asn: u32 = rng.gen();
-                match tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(asn))) {
+                match tree_bitmap.insert(
+                    &pfx.unwrap(),
+                    Record::new(0, 0, RouteStatus::Active, PrefixAs(asn)),
+                    None
+                ) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/examples/single_thread_24.rs
+++ b/examples/single_thread_24.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // x += 1;
                 // print!("{}-", i);
                 let asn: u32 = rng.gen();
-                match tree_bitmap.insert(&pfx.unwrap(), 0, PrefixAs(asn)) {
+                match tree_bitmap.insert(&pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(asn))) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/examples/treebitmap.rs
+++ b/examples/treebitmap.rs
@@ -294,9 +294,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &spfx.unwrap(),
             &MatchOptions {
                 match_type: MatchType::LongestMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: false,
+                mui: None
             },
             guard
         );

--- a/examples/treebitmap.rs
+++ b/examples/treebitmap.rs
@@ -184,7 +184,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for pfx in pfxs.into_iter() {
         // println!("insert {:?}", pfx);
-        tree_bitmap.insert(&pfx.unwrap(), NoMeta::Empty)?;
+        tree_bitmap.insert(&pfx.unwrap(), 0, NoMeta::Empty)?;
     }
     println!("------ end of inserts\n");
     // println!("{:#?}", tree_bitmap.store.prefixes);

--- a/examples/treebitmap.rs
+++ b/examples/treebitmap.rs
@@ -184,7 +184,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     for pfx in pfxs.into_iter() {
         // println!("insert {:?}", pfx);
-        tree_bitmap.insert(&pfx.unwrap(), 0, NoMeta::Empty)?;
+        tree_bitmap.insert(
+            &pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
     }
     println!("------ end of inserts\n");
     // println!("{:#?}", tree_bitmap.store.prefixes);

--- a/examples/treebitmap.rs
+++ b/examples/treebitmap.rs
@@ -185,7 +185,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for pfx in pfxs.into_iter() {
         // println!("insert {:?}", pfx);
         tree_bitmap.insert(
-            &pfx.unwrap(), Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
+            &pfx.unwrap(), 
+            Record::new(0, 0, RouteStatus::Active, NoMeta::Empty),
+            None
+        )?;
     }
     println!("------ end of inserts\n");
     // println!("{:#?}", tree_bitmap.store.prefixes);

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -71,7 +71,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start = std::time::Instant::now();
 
     for pfx in pfxs.into_iter() {
-        tree_bitmap.insert(&pfx.prefix, pfx.meta)?;
+        tree_bitmap.insert(&pfx.prefix, 0, pfx.meta)?;
     }
     let ready = std::time::Instant::now();
     // println!("{:#?}", tree_bitmap.store.prefixes);

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -219,9 +219,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     &p,
                                     &MatchOptions {
                                         match_type: MatchType::ExactMatch,
-                                        include_all_records: true,
+                                        include_withdrawn: true,
                                         include_less_specifics: true,
                                         include_more_specifics: true,
+                                        mui: None,
                                     },
                                     guard,
                                 );
@@ -250,7 +251,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     tree_bitmap
                                         .more_specifics_from(
                                             &Prefix::new_relaxed(ip, len)?,
-                                            guard
+                                            None,
+                                            guard,
                                         )
                                         .more_specifics
                                         .map_or("None".to_string(), |x| x
@@ -262,7 +264,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     tree_bitmap
                                         .less_specifics_from(
                                             &Prefix::new_relaxed(ip, len)?,
-                                            guard
+                                            None,
+                                            guard,
                                         )
                                         .less_specifics
                                         .map_or("None".to_string(), |x| x
@@ -280,9 +283,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         &MatchOptions {
                                             match_type:
                                                 MatchType::ExactMatch,
-                                            include_all_records: true,
+                                            include_withdrawn: true,
                                             include_less_specifics: true,
-                                            include_more_specifics: true
+                                            include_more_specifics: true,
+                                            mui: None
                                         },
                                         guard
                                     )
@@ -294,7 +298,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     tree_bitmap
                                         .more_specifics_from(
                                             &Prefix::new_relaxed(ip, len)?,
-                                            guard
+                                            None,
+                                            guard,
                                         )
                                         .more_specifics
                                         .map_or("None".to_string(), |x| x
@@ -306,6 +311,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     tree_bitmap
                                         .less_specifics_from(
                                             &Prefix::new_relaxed(ip, len)?,
+                                            None,
                                             guard
                                         )
                                         .less_specifics

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -40,7 +40,7 @@ fn load_prefixes(
         let asn: u32 = record[2].parse().unwrap();
         let pfx = PrefixRecord::new(
             Prefix::new(ip, len)?,
-            PrefixAs(asn),
+            vec![Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(asn))],
         );
 
         // let ip: Vec<_> = record[0]
@@ -71,7 +71,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start = std::time::Instant::now();
 
     for pfx in pfxs.into_iter() {
-        tree_bitmap.insert(&pfx.prefix, 0, pfx.meta)?;
+        tree_bitmap.insert(&pfx.prefix, pfx.meta[0].clone())?;
     }
     let ready = std::time::Instant::now();
     // println!("{:#?}", tree_bitmap.store.prefixes);
@@ -104,7 +104,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         .for_each(|pfx| {
                                             println!(
                                                 "{} {}",
-                                                pfx.prefix, pfx.meta
+                                                pfx.prefix, pfx.meta[0]
                                             );
                                         });
                                     println!(
@@ -118,7 +118,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         .for_each(|pfx| {
                                             println!(
                                                 "{} {}",
-                                                pfx.prefix, pfx.meta
+                                                pfx.prefix, pfx.meta[0]
                                             );
                                         });
                                     println!(
@@ -140,7 +140,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         .for_each(|pfx| {
                                             println!(
                                                 "{} {}",
-                                                pfx.prefix, pfx.meta
+                                                pfx.prefix, pfx.meta[0]
                                             );
                                         });
                                     println!(

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -40,7 +40,7 @@ fn load_prefixes(
         let asn: u32 = record[2].parse().unwrap();
         let pfx = PrefixRecord::new(
             Prefix::new(ip, len)?,
-            vec![Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(asn))],
+            vec![Record::new(0, 0, RouteStatus::Active, PrefixAs(asn))],
         );
 
         // let ip: Vec<_> = record[0]
@@ -71,7 +71,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start = std::time::Instant::now();
 
     for pfx in pfxs.into_iter() {
-        tree_bitmap.insert(&pfx.prefix, pfx.meta[0].clone())?;
+        tree_bitmap.insert(&pfx.prefix, pfx.meta[0].clone(), None)?;
     }
     let ready = std::time::Instant::now();
     // println!("{:#?}", tree_bitmap.store.prefixes);

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -252,6 +252,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         .more_specifics_from(
                                             &Prefix::new_relaxed(ip, len)?,
                                             None,
+                                            false,
                                             guard,
                                         )
                                         .more_specifics
@@ -265,6 +266,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         .less_specifics_from(
                                             &Prefix::new_relaxed(ip, len)?,
                                             None,
+                                            false,
                                             guard,
                                         )
                                         .less_specifics
@@ -299,6 +301,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         .more_specifics_from(
                                             &Prefix::new_relaxed(ip, len)?,
                                             None,
+                                            false,
                                             guard,
                                         )
                                         .more_specifics
@@ -312,6 +315,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         .less_specifics_from(
                                             &Prefix::new_relaxed(ip, len)?,
                                             None,
+                                            false,
                                             guard
                                         )
                                         .less_specifics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! A treebitmap based Prefix Store
+//! A treebitmap based IP Prefix Store
 
 //! IP prefixes storage and retrieval data structures for IPv4 and IPv6 prefixes.
 //! This crate contains structures for both single and multi-threaded contexts, as
@@ -7,7 +7,7 @@
 //! The underlying tree structure is based on the tree bitmap as outlined in
 //! [this paper](https://www.cs.cornell.edu/courses/cs419/2005sp/tree-bitmap.pdf).
 //!
-//! Part of the (upcoming) Rotonda modular BGP engine.
+//! Part of the Rotonda modular BGP engine.
 
 //! Read more about the data-structure in this [blog post](https://blog.nlnetlabs.nl/donkeys-mules-horses/).
 mod af;

--- a/src/local_array/macros.rs
+++ b/src/local_array/macros.rs
@@ -6,7 +6,7 @@
 macro_rules! insert_match {
     (
         $self: ident;
-        $user_data: ident;
+        // $user_data: ident;
         // $multi_uniq_id: ident;
         $guard: ident;
         $nibble_len: expr;

--- a/src/local_array/macros.rs
+++ b/src/local_array/macros.rs
@@ -143,11 +143,7 @@ macro_rules! insert_match {
                         }
                         return Err(PrefixStoreError::NodeCreationMaxRetryError);
                     }
-                    if $back_off.is_completed() {
-                        std::thread::park();
-                    } else {
-                        $back_off.snooze();
-                    }
+                    $back_off.spin();
                 }
             }
         }

--- a/src/local_array/macros.rs
+++ b/src/local_array/macros.rs
@@ -7,6 +7,7 @@ macro_rules! insert_match {
     (
         $self: ident;
         $user_data: ident;
+        $multi_uniq_id: ident;
         $guard: ident;
         $nibble_len: expr;
         $nibble: expr; // nibble is a variable-length bitarray (1,2,4,8,etc)
@@ -48,7 +49,8 @@ macro_rules! insert_match {
             // retry_count from this macro.
             let mut local_retry_count = 0;
             loop {
-                if let Some(current_node) = $self.store.retrieve_node_mut_with_guard($cur_i, $guard) {
+                // retrieve_node_mut_with_guard updates the bitmap index if necessary.
+                if let Some(current_node) = $self.store.retrieve_node_mut_with_guard($cur_i, $multi_uniq_id, $guard) {
                     match current_node {
                         $(
                             SizedStrideRefMut::$variant(current_node) => {
@@ -77,7 +79,7 @@ macro_rules! insert_match {
                                         // store. It returns the created id
                                         // and the number of retries before
                                         // success.
-                                        match $self.store.store_node(new_id, n, $guard) {
+                                        match $self.store.store_node(new_id, $multi_uniq_id, n, $guard) {
                                             Ok((node_id, s_retry_count)) => {
                                                 break Ok((node_id, $acc_retry_count + s_retry_count + retry_count));
                                             },

--- a/src/local_array/macros.rs
+++ b/src/local_array/macros.rs
@@ -14,6 +14,7 @@ macro_rules! insert_match {
         $is_last_stride: expr;
         $pfx: ident; // the whole search prefix
         $record: ident; // the record holding the metadata
+        $update_path_selections: ident; // boolean indicate whether to update the path selections for this route
         $truncate_len: ident; // the start of the length of this stride
         $stride_len: ident; // the length of this stride
         $cur_i: expr; // the id of the current node in this stride
@@ -100,7 +101,7 @@ macro_rules! insert_match {
                                         break Ok((node_id, $acc_retry_count + local_retry_count + retry_count))
                                     },
                                     (NewNodeOrIndex::NewPrefix, retry_count) => {
-                                        return $self.store.upsert_prefix($pfx, $record, $guard)
+                                        return $self.store.upsert_prefix($pfx, $record, $update_path_selections, $guard)
                                             .and_then(|mut r| {
                                                 r.cas_count += $acc_retry_count as usize + local_retry_count as usize + retry_count as usize;
                                                 Ok(r)
@@ -109,7 +110,7 @@ macro_rules! insert_match {
                                         // $self.stats[$stats_level].inc_prefix_count($level);
                                     }
                                     (NewNodeOrIndex::ExistingPrefix, retry_count) => {
-                                        return $self.store.upsert_prefix($pfx, $record, $guard)
+                                        return $self.store.upsert_prefix($pfx, $record, $update_path_selections, $guard)
                                             .and_then(|mut r| { 
                                                 r.cas_count += $acc_retry_count as usize + local_retry_count as usize + retry_count as usize;
                                                 Ok(r) 

--- a/src/local_array/macros.rs
+++ b/src/local_array/macros.rs
@@ -100,7 +100,7 @@ macro_rules! insert_match {
                                         break Ok((node_id, $acc_retry_count + local_retry_count + retry_count))
                                     },
                                     (NewNodeOrIndex::NewPrefix, retry_count) => {
-                                        return $self.store.upsert_prefix($pfx, $record, $guard, $user_data)
+                                        return $self.store.upsert_prefix($pfx, $record, $guard)
                                             .and_then(|mut r| {
                                                 r.cas_count += $acc_retry_count as usize + local_retry_count as usize + retry_count as usize;
                                                 Ok(r)
@@ -109,7 +109,7 @@ macro_rules! insert_match {
                                         // $self.stats[$stats_level].inc_prefix_count($level);
                                     }
                                     (NewNodeOrIndex::ExistingPrefix, retry_count) => {
-                                        return $self.store.upsert_prefix($pfx, $record, $guard, $user_data)
+                                        return $self.store.upsert_prefix($pfx, $record, $guard)
                                             .and_then(|mut r| { 
                                                 r.cas_count += $acc_retry_count as usize + local_retry_count as usize + retry_count as usize;
                                                 Ok(r) 

--- a/src/local_array/node.rs
+++ b/src/local_array/node.rs
@@ -132,7 +132,6 @@ where
             base_prefix,
             start_bit_span,
             cursor: None,
-            _af: PhantomData,
         }
     }
 
@@ -743,7 +742,6 @@ pub(crate) struct NodeMoreSpecificChildIter<AF: AddressFamily, S: Stride> {
    ptrbitarr: <<S as Stride>::AtomicPtrSize as AtomicBitmap>::InnerType,
    start_bit_span: BitSpan,
    cursor: Option<u32>,
-   _af: PhantomData<AF>,
 }
 
 impl<AF: AddressFamily, S: Stride> std::iter::Iterator for

--- a/src/local_array/query.rs
+++ b/src/local_array/query.rs
@@ -47,7 +47,7 @@ where
                 None
             },
             prefix_meta: prefix.map(|r| {
-                r.record_map.as_public_records_vec()
+                r.record_map.as_public_records()
             }).unwrap_or_default(),
             match_type: MatchType::EmptyMatch,
             less_specifics: None,
@@ -82,7 +82,7 @@ where
                 None
             },
             prefix_meta: prefix.map(|r| {
-                r.record_map.as_public_records_vec()
+                r.record_map.as_public_records()
             }).unwrap_or_default(),
             match_type: MatchType::EmptyMatch,
             less_specifics: less_specifics_vec.map(|iter| iter.collect()),
@@ -113,7 +113,7 @@ where
             .store
             .non_recursive_retrieve_prefix_with_guard(search_pfx, guard)
             .0
-            .map(|pfx| (pfx.prefix, pfx.record_map.as_public_records_vec()));
+            .map(|pfx| (pfx.prefix, pfx.record_map.as_public_records()));
 
         // Check if we have an actual exact match, if not then fetch the
         // first lesser-specific with the greatest length, that's the Longest
@@ -237,7 +237,7 @@ where
                             PrefixId::new(AF::zero(), 0),
                             guard,
                         )
-                        .map(|sp| sp.0.record_map.as_public_records_vec()).unwrap_or_default();
+                        .map(|sp| sp.0.record_map.as_public_records()).unwrap_or_default();
                     return QueryResult {
                         prefix: Prefix::new(
                             search_pfx.get_net().into_ipaddr(),
@@ -728,7 +728,7 @@ where
             prefix: prefix.map(|pfx: (&StoredPrefix<AF, M>, usize)| {
                 pfx.0.prefix.into_pub()
             }),
-            prefix_meta: prefix.map(|pfx| pfx.0.record_map.as_public_records_vec()).unwrap_or_default(),
+            prefix_meta: prefix.map(|pfx| pfx.0.record_map.as_public_records()).unwrap_or_default(),
             match_type,
             less_specifics: if options.include_less_specifics {
                 less_specifics_vec
@@ -737,7 +737,7 @@ where
                     .filter_map(move |p| {
                         self.store
                             .retrieve_prefix_with_guard(*p, guard)
-                            .map(|p| Some((p.0.prefix, p.0.record_map.as_public_records_vec())))
+                            .map(|p| Some((p.0.prefix, p.0.record_map.as_public_records())))
                     })
                     .collect()
             } else {
@@ -756,7 +756,7 @@ where
                                     )
                                 })
                                 .0
-                        }).map(|sp| (sp.prefix, sp.record_map.as_public_records_vec()))
+                        }).map(|sp| (sp.prefix, sp.record_map.as_public_records()))
                         .collect()
                 })
             } else {

--- a/src/local_array/query.rs
+++ b/src/local_array/query.rs
@@ -4,7 +4,7 @@ use epoch::Guard;
 use crate::af::AddressFamily;
 use crate::local_array::store::atomic_types::{NodeBuckets, PrefixBuckets};
 use inetnum::addr::Prefix;
-use crate::prefix_record::{MergeUpdate, Meta, PublicRecord};
+use crate::prefix_record::{Meta, PublicRecord};
 
 use crate::QueryResult;
 
@@ -20,7 +20,7 @@ use super::store::atomic_types::StoredPrefix;
 impl<'a, AF, M, NB, PB> TreeBitMap<AF, M, NB, PB>
 where
     AF: AddressFamily,
-    M: Meta + MergeUpdate,
+    M: Meta,
     NB: NodeBuckets<AF>,
     PB: PrefixBuckets<AF, M>,
 {

--- a/src/local_array/query.rs
+++ b/src/local_array/query.rs
@@ -130,7 +130,7 @@ where
                         // Do no filter out any records, but do rewrite the
                         // local statuses of the records with muis that
                         // appear in the specified bitmap index.
-                        pfx.record_map.as_records_with_global_status(
+                        pfx.record_map.as_records_with_rewritten_status(
                             unsafe { 
                                 self.store.withdrawn_muis_bmin.load(
                                     Ordering::Acquire, guard

--- a/src/local_array/query.rs
+++ b/src/local_array/query.rs
@@ -2,7 +2,6 @@ use std::sync::atomic::Ordering;
 
 use crossbeam_epoch::{self as epoch};
 use epoch::Guard;
-use roaring::RoaringBitmap;
 
 use crate::af::AddressFamily;
 use crate::local_array::store::atomic_types::{NodeBuckets, PrefixBuckets};

--- a/src/local_array/store/atomic_types.rs
+++ b/src/local_array/store/atomic_types.rs
@@ -183,7 +183,7 @@ impl<AF: AddressFamily, M: crate::prefix_record::Meta> StoredPrefix<AF, M> {
         };
         // End of calculation
 
-        let mut rec_map = HashMap::new();
+        let rec_map = HashMap::new();
         rec_map.pin().insert(record.multi_uniq_id, MultiMapValue::from(record));
 
         StoredPrefix {
@@ -198,7 +198,7 @@ impl<AF: AddressFamily, M: crate::prefix_record::Meta> StoredPrefix<AF, M> {
         self.prefix
     }
 
-    pub fn upsert_record<'a, PB: PrefixBuckets<AF, M>>(
+    pub(crate) fn upsert_record<'a, PB: PrefixBuckets<AF, M>>(
         &'a self,
         record: MultiMapValue<M>,
         multi_uniq_id: u32,
@@ -351,7 +351,7 @@ impl<M: Send + Sync + Debug + Display + Meta> MultiMap<M> {
         self.0.pin().iter().map(PublicRecord::from).collect::<Vec<_>>()
     }
 
-    // Insert of replace the PublicRecord in the HashMap for the key of
+    // Insert or replace the PublicRecord in the HashMap for the key of
     // record.multi_uniq_id. Returns the number of entries in the HashMap
     // after updating it.
     pub fn upsert_record(&self, record: PublicRecord<M>) -> Option<usize> {

--- a/src/local_array/store/atomic_types.rs
+++ b/src/local_array/store/atomic_types.rs
@@ -267,7 +267,7 @@ impl std::fmt::Display for RouteStatus {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct MultiMapValue<M> where M: Clone {
+pub(crate) struct MultiMapValue<M> {
     pub meta: M,
     pub ltime: u64,
     pub status: RouteStatus
@@ -300,11 +300,11 @@ impl<M: Meta> From<PublicRecord<M>> for MultiMapValue<M> {
 // prefix.
 
 #[derive(Clone, Debug)]
-pub(crate) struct MultiMap<M: Send + Sync + Clone>(
+pub(crate) struct MultiMap<M: Send + Sync>(
     flurry::HashMap<u32, MultiMapValue<M>>
 );
 
-impl<M: Send + Sync + Clone + Debug + Display + Meta> MultiMap<M> {
+impl<M: Send + Sync + Debug + Display + Meta> MultiMap<M> {
     pub fn new(record_map: HashMap<u32, MultiMapValue<M>>) -> Self {
         Self(record_map)
     }

--- a/src/local_array/store/atomic_types.rs
+++ b/src/local_array/store/atomic_types.rs
@@ -221,7 +221,7 @@ impl<AF: AddressFamily, M: crate::prefix_record::Meta> StoredPrefix<AF, M> {
         }
     }
 
-    pub(crate) fn new_with_record<PB: PrefixBuckets<AF, M>>(
+    pub(crate) fn _new_with_record<PB: PrefixBuckets<AF, M>>(
         pfx_id: PrefixId<AF>,
         record: PublicRecord<M>,
         level: u8,
@@ -274,7 +274,7 @@ impl<AF: AddressFamily, M: crate::prefix_record::Meta> StoredPrefix<AF, M> {
         self.prefix
     }
 
-    pub(crate) fn get_path_selections(
+    pub(crate) fn _get_path_selections(
         &self,
         guard: &Guard,
     ) -> Option<(PathSelections, usize)> {
@@ -334,7 +334,7 @@ pub(crate) struct MultiMapValue<M> {
 }
 
 impl<M: Clone> MultiMapValue<M> {
-    pub(crate) fn new(meta: M, ltime: u64, status: RouteStatus) -> Self {
+    pub(crate) fn _new(meta: M, ltime: u64, status: RouteStatus) -> Self {
         Self {
             meta,
             ltime,
@@ -425,7 +425,7 @@ impl<M: Send + Sync + Debug + Display + Meta> MultiMap<M> {
         }
     }
 
-    pub fn iter_all_records<'a>(
+    pub fn _iter_all_records<'a>(
         &'a self,
         guard: &'a flurry::Guard<'a>,
     ) -> impl Iterator<Item = PublicRecord<M>> + 'a {
@@ -547,7 +547,7 @@ impl<AF: AddressFamily, Meta: crate::prefix_record::Meta>
         }
     }
 
-    pub(crate) fn get_stored_prefix_with_tag<'a>(
+    pub(crate) fn _get_stored_prefix_with_tag<'a>(
         &'a self,
         guard: &'a Guard,
     ) -> Option<(&'a StoredPrefix<AF, Meta>, usize)> {
@@ -620,7 +620,7 @@ impl<AF: AddressFamily, Meta: crate::prefix_record::Meta>
             unsafe { self.0.load(Ordering::Acquire, guard).as_ref() }
         {
             let flurry_guard = stored_prefix.record_map.guard();
-            let paths_iter = stored_prefix.record_map.0.iter(&flurry_guard);
+            let _paths_iter = stored_prefix.record_map.0.iter(&flurry_guard);
             // let path_selections_mui = routecore::some_path_selection_procedure(paths_iter);
             let path_selections_mui = PathSelections {
                 path_selection_muis: (None, None),

--- a/src/local_array/store/atomic_types.rs
+++ b/src/local_array/store/atomic_types.rs
@@ -394,6 +394,22 @@ impl<M: Send + Sync + Debug + Display + Meta> MultiMap<M> {
         })
     }
 
+
+    pub(crate) fn get_record_for_mui_with_rewritten_status(
+        &self,
+        mui: u32,
+        bmin: &RoaringBitmap,
+        rewrite_status: RouteStatus
+    ) -> Option<PublicRecord<M>> {
+        self.0.get(&mui, &self.0.guard()).map(|r| {
+            let mut r = r.clone();
+            if bmin.contains(mui) {
+                r.status = rewrite_status;
+            }
+            PublicRecord::from((mui, r))
+        })
+    }
+
     pub fn iter_all_records<'a>(
         &'a self,
         guard: &'a flurry::Guard<'a>,
@@ -407,7 +423,7 @@ impl<M: Send + Sync + Debug + Display + Meta> MultiMap<M> {
     // set status for the mui of the record. However, the local status for a
     // record whose mui appears in the specified bitmap index, will be
     // rewritten with the specified RouteStatus.
-    pub fn as_records_with_global_status(
+    pub fn as_records_with_rewritten_status(
         &self,
         bmin: &RoaringBitmap,
         rewrite_status: RouteStatus,

--- a/src/local_array/store/atomic_types.rs
+++ b/src/local_array/store/atomic_types.rs
@@ -410,6 +410,21 @@ impl<M: Send + Sync + Debug + Display + Meta> MultiMap<M> {
         })
     }
 
+
+    // Helper to filter out records that are not-active (Inactive or
+    // Withdrawn), or whose mui appears in the global withdrawn index.
+    pub fn get_filtered_records(
+        &self, 
+        mui: Option<u32>,
+        bmin: &RoaringBitmap,
+    ) -> Vec<PublicRecord<M>> {
+        if let Some(mui) = mui {
+            self.get_record_for_active_mui(mui).into_iter().collect()
+        } else {
+            self.as_active_records_not_in_bmin(bmin) 
+        }
+    }
+
     pub fn iter_all_records<'a>(
         &'a self,
         guard: &'a flurry::Guard<'a>,

--- a/src/local_array/store/atomic_types.rs
+++ b/src/local_array/store/atomic_types.rs
@@ -279,7 +279,7 @@ impl<AF: AddressFamily, M: crate::prefix_record::Meta> StoredPrefix<AF, M> {
         guard: &Guard,
     ) -> Option<(PathSelections, usize)> {
         let path_selections =
-            self.path_selections.load(Ordering::Release, guard);
+            self.path_selections.load(Ordering::Acquire, guard);
         unsafe { path_selections.as_ref() }
             .map(|ps| (*ps, path_selections.tag()))
     }
@@ -289,7 +289,7 @@ impl<AF: AddressFamily, M: crate::prefix_record::Meta> StoredPrefix<AF, M> {
         path_selections: PathSelections,
         guard: &Guard,
     ) -> Result<(), PrefixStoreError> {
-        let current = self.path_selections.load(Ordering::AcqRel, guard);
+        let current = self.path_selections.load(Ordering::Acquire, guard);
 
         if unsafe { current.as_ref() } == Some(&path_selections) {
             return Ok(());
@@ -300,7 +300,7 @@ impl<AF: AddressFamily, M: crate::prefix_record::Meta> StoredPrefix<AF, M> {
                 current,
                 Owned::new(path_selections),
                 Ordering::AcqRel,
-                Ordering::Release,
+                Ordering::Acquire,
                 guard,
             )
             .map_err(|_| PrefixStoreError::PathSelectionOutdated)?;
@@ -542,7 +542,7 @@ impl<AF: AddressFamily, Meta: crate::prefix_record::Meta>
     #[allow(dead_code)]
     pub(crate) fn get_serial(&self) -> usize {
         let guard = &epoch::pin();
-        unsafe { self.0.load(Ordering::AcqRel, guard).into_owned() }.tag()
+        unsafe { self.0.load(Ordering::Acquire, guard).into_owned() }.tag()
     }
 
     pub(crate) fn get_prefix_id(&self) -> PrefixId<AF> {

--- a/src/local_array/store/custom_alloc.rs
+++ b/src/local_array/store/custom_alloc.rs
@@ -187,9 +187,7 @@
 
 use std::{
     fmt::Debug,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::atomic::{AtomicUsize, Ordering}
 };
 
 use log::{debug, info, log_enabled, trace};

--- a/src/local_array/store/custom_alloc.rs
+++ b/src/local_array/store/custom_alloc.rs
@@ -201,7 +201,7 @@ use std::marker::PhantomData;
 use crate::{local_array::tree::*, stats::CreatedNodes};
 use crate::{
     local_array::{bit_span::BitSpan, store::errors::PrefixStoreError},
-    prefix_record::{MergeUpdate, PublicRecord},
+    prefix_record::PublicRecord,
 };
 
 // use crate::prefix_record::InternalPrefixRecord;

--- a/src/local_array/store/custom_alloc.rs
+++ b/src/local_array/store/custom_alloc.rs
@@ -837,6 +837,7 @@ impl<
         let mut new = unsafe { current.as_ref() }.unwrap().clone();
         new.insert(mui);
 
+        #[allow(clippy::assigning_clones)]
         loop {
             match self.withdrawn_muis_bmin.compare_exchange(
                 current,
@@ -861,6 +862,7 @@ impl<
         let mut new = unsafe { current.as_ref() }.unwrap().clone();
         new.remove(mui);
 
+        #[allow(clippy::assigning_clones)]
         loop {
             match self.withdrawn_muis_bmin.compare_exchange(
                 current,

--- a/src/local_array/store/custom_alloc.rs
+++ b/src/local_array/store/custom_alloc.rs
@@ -803,7 +803,7 @@ impl<
 
     // Change the status of the record for the specified (prefix, mui)
     // combination  to Withdrawn.
-    pub fn mark_mui_as_withdrawn_for_prefix(&mut self, prefix: PrefixId<AF>, mui: u32, guard: &Guard) -> Result<(), PrefixStoreError> {
+    pub fn mark_mui_as_withdrawn_for_prefix(&self, prefix: PrefixId<AF>, mui: u32, guard: &Guard) -> Result<(), PrefixStoreError> {
         let (atomic_stored_prefix, _level) = self
             .non_recursive_retrieve_prefix_mut_with_guard(
                 prefix, guard,
@@ -817,7 +817,7 @@ impl<
 
     // Change the status of the record for the specified (prefix, mui)
     // combination  to Active.
-    pub fn mark_mui_as_active_for_prefix(&mut self, prefix: PrefixId<AF>, mui: u32, guard: &Guard) -> Result<(), PrefixStoreError> {
+    pub fn mark_mui_as_active_for_prefix(&self, prefix: PrefixId<AF>, mui: u32, guard: &Guard) -> Result<(), PrefixStoreError> {
         let (atomic_stored_prefix, _level) = self
             .non_recursive_retrieve_prefix_mut_with_guard(
                 prefix, guard,
@@ -831,7 +831,7 @@ impl<
 
     // Change the status of the mui globally to Withdrawn. Iterators and match
     // functions will by default not return any records for this mui.
-    pub fn mark_mui_as_withdrawn(&mut self, mui: u32, guard: &Guard) -> Result<(), PrefixStoreError> {
+    pub fn mark_mui_as_withdrawn(&self, mui: u32, guard: &Guard) -> Result<(), PrefixStoreError> {
         let current = self.withdrawn_muis_bmin.load(Ordering::Acquire, guard);
 
         let mut new = unsafe { current.as_ref() }.unwrap().clone();
@@ -856,7 +856,7 @@ impl<
 
     // Change the status of the mui globally to Active. Iterators and match
     // functions will default to the status on the record itself.
-    pub fn mark_mui_as_active(&mut self, mui: u32, guard: &Guard) -> Result<(), PrefixStoreError> {
+    pub fn mark_mui_as_active(&self, mui: u32, guard: &Guard) -> Result<(), PrefixStoreError> {
         let current = self.withdrawn_muis_bmin.load(Ordering::Acquire, guard);
 
         let mut new = unsafe { current.as_ref() }.unwrap().clone();

--- a/src/local_array/store/custom_alloc.rs
+++ b/src/local_array/store/custom_alloc.rs
@@ -315,11 +315,11 @@ pub struct DegreeOfPreference(pub u32);
 
 #[derive(Debug, Copy, Clone)]
 pub struct TieBreakerInfo {
-    source: RouteSource,
-    degree_of_preference: Option<DegreeOfPreference>,
-    local_asn: inetnum::asn::Asn,
+    _source: RouteSource,
+    _degree_of_preference: Option<DegreeOfPreference>,
+    _local_asn: inetnum::asn::Asn,
     // bgp_idenfitier: BgpIdentifier,
-    peer_addr:  std::net::IpAddr,
+    _peer_addr:  std::net::IpAddr,
 }
 
 // ----------- CustomAllocStorage -------------------------------------------

--- a/src/local_array/store/custom_alloc.rs
+++ b/src/local_array/store/custom_alloc.rs
@@ -363,7 +363,7 @@ impl<
         // multi_uniq_id: u32,
         guard: &'a Guard,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        info!("store: initialize store");
+        info!("store: initialize store {}", AF::BITS);
 
         let store = CustomAllocStorage {
             buckets: NodeBuckets::<AF>::init(),
@@ -432,10 +432,11 @@ impl<
 
         if log_enabled!(log::Level::Trace) {
             debug!(
-                "{} store: Store node {}: {:?}",
+                "{} store: Store node {}: {:?} mui {}",
                 std::thread::current().name().unwrap(),
                 id,
-                next_node
+                next_node,
+                multi_uniq_id
             );
         }
         self.counters.inc_nodes_count();
@@ -545,10 +546,11 @@ impl<
 
         if log_enabled!(log::Level::Trace) {
             trace!(
-                "{} store: Retrieve node {} from l{}",
+                "{} store: Retrieve node {} from l{} for mui {}",
                 std::thread::current().name().unwrap(),
                 id,
-                id.get_id().1
+                id.get_id().1,
+                mui
             );
         }
 
@@ -598,7 +600,7 @@ impl<
 
         if log_enabled!(log::Level::Trace) {
             trace!(
-                "{} store: Retrieve node {} from l{}",
+                "{} store: Retrieve node mut {} from l{}",
                 std::thread::current().name().unwrap(),
                 id,
                 id.get_id().1

--- a/src/local_array/store/custom_alloc.rs
+++ b/src/local_array/store/custom_alloc.rs
@@ -604,7 +604,7 @@ impl<
         prefix: PrefixId<AF>,
         record: PublicRecord<M>,
         guard: &Guard,
-        user_data: Option<&<M as MergeUpdate>::UserDataIn>,
+        // user_data: Option<&<M as MergeUpdate>::UserDataIn>,
     ) -> Result<UpsertReport, PrefixStoreError> {
         let mut retry_count = 0;
         let multi_uniq_id = record.multi_uniq_id;

--- a/src/local_array/store/default_store.rs
+++ b/src/local_array/store/default_store.rs
@@ -11,7 +11,7 @@ use crate::prelude::multi::*;
 struct DefaultStore;
 
 impl<
-        M: Meta + MergeUpdate,
+        M: Meta,
         NB: NodeBuckets<IPv4>,
         PB: PrefixBuckets<IPv4, M>
     > fmt::Display for CustomAllocStorage<IPv4, M, NB, PB>
@@ -26,7 +26,7 @@ impl<
 }
 
 impl<
-        M: Meta + MergeUpdate,
+        M: Meta,
         NB: NodeBuckets<IPv6>,
         PB: PrefixBuckets<IPv6, M>
     > fmt::Display for CustomAllocStorage<IPv6, M, NB, PB>

--- a/src/local_array/store/default_store.rs
+++ b/src/local_array/store/default_store.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use crate::prelude::*;
 use crate::prelude::multi::*;
-use crate::local_array::store::atomic_types::RouteStatus;
 
 // The default stride sizes for IPv4, IPv6, resp.
 #[create_store((

--- a/src/local_array/store/default_store.rs
+++ b/src/local_array/store/default_store.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use crate::prelude::*;
 use crate::prelude::multi::*;
+use crate::local_array::store::atomic_types::RouteStatus;
 
 // The default stride sizes for IPv4, IPv6, resp.
 #[create_store((

--- a/src/local_array/store/errors.rs
+++ b/src/local_array/store/errors.rs
@@ -1,12 +1,13 @@
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum PrefixStoreError {
     NodeCreationMaxRetryError,
     NodeNotFound,
     StoreNotReadyError,
     PathSelectionOutdated,
-    PrefixNotFound
+    PrefixNotFound,
+    BestPathNotFound
 }
 
 impl std::error::Error for PrefixStoreError {}
@@ -29,6 +30,9 @@ impl fmt::Display for PrefixStoreError {
             }
             PrefixStoreError::PrefixNotFound => {
                 write!(f, "Error: The Prefix cannot be found.")
+            }
+            PrefixStoreError::BestPathNotFound => {
+                write!(f, "Error: The Prefix does not have a stored best path.")
             }
         }
     }

--- a/src/local_array/store/errors.rs
+++ b/src/local_array/store/errors.rs
@@ -5,6 +5,7 @@ pub enum PrefixStoreError {
     NodeCreationMaxRetryError,
     NodeNotFound,
     StoreNotReadyError,
+    PathSelectionOutdated
 }
 
 impl std::error::Error for PrefixStoreError {}
@@ -21,6 +22,9 @@ impl fmt::Display for PrefixStoreError {
             }
             PrefixStoreError::StoreNotReadyError => {
                 write!(f, "Error: Store isn't ready yet.")
+            }
+            PrefixStoreError::PathSelectionOutdated => {
+                write!(f, "Error: The Path Selection process is based on outdated paths.")
             }
         }
     }

--- a/src/local_array/store/errors.rs
+++ b/src/local_array/store/errors.rs
@@ -5,7 +5,8 @@ pub enum PrefixStoreError {
     NodeCreationMaxRetryError,
     NodeNotFound,
     StoreNotReadyError,
-    PathSelectionOutdated
+    PathSelectionOutdated,
+    PrefixNotFound
 }
 
 impl std::error::Error for PrefixStoreError {}
@@ -25,6 +26,9 @@ impl fmt::Display for PrefixStoreError {
             }
             PrefixStoreError::PathSelectionOutdated => {
                 write!(f, "Error: The Path Selection process is based on outdated paths.")
+            }
+            PrefixStoreError::PrefixNotFound => {
+                write!(f, "Error: The Prefix cannot be found.")
             }
         }
     }

--- a/src/local_array/store/iterators.rs
+++ b/src/local_array/store/iterators.rs
@@ -269,7 +269,7 @@ impl<AF: AddressFamily> SizedPrefixIter<AF> {
 // A iterator over all the more-specifics for a given prefix.
 //
 // This iterator is somewhat different from the other *PrefixIterator types,
-// since it uses the Nodes to select the more specifics. Am Iterator that
+// since it uses the Nodes to select the more specifics. An Iterator that
 // would only use the Prefixes in the store could exist, but iterating over
 // those in search of more specifics would be way more expensive.
 

--- a/src/local_array/store/iterators.rs
+++ b/src/local_array/store/iterators.rs
@@ -195,7 +195,7 @@ impl<'a, AF: AddressFamily + 'a, M: Meta + 'a, PB: PrefixBuckets<AF, M>>
                                 // There's a prefix here, that's the next one
                                 trace!("D. found prefix {:?}", p.prefix);
                             }
-                            p.record_map.as_public_records_vec()
+                            p.record_map.as_public_records()
                         })
                     {
                         return Some((
@@ -216,7 +216,7 @@ impl<'a, AF: AddressFamily + 'a, M: Meta + 'a, PB: PrefixBuckets<AF, M>>
                             if log_enabled!(log::Level::Debug) {
                                 debug!("E. found prefix {:?}", p.prefix);
                             }
-                            p.record_map.as_public_records_vec()
+                            p.record_map.as_public_records()
                         })
                     {
                         self.cursor += 1;
@@ -335,7 +335,7 @@ impl<
                         ),
                         self.guard,
                     )
-                    .0.map(|p| (p.prefix, p.record_map.as_public_records_vec()));
+                    .0.map(|p| (p.prefix, p.record_map.as_public_records()));
             }
 
             // Our current prefix iterator for this node is done, look for
@@ -519,7 +519,7 @@ impl<'a, AF: AddressFamily + 'a, M: Meta + 'a, PB: PrefixBuckets<AF, M>>
 
             if let Some(stored_prefix) = s_pfx.get_stored_prefix(self.guard) {
                 trace!("get_record {:?}", stored_prefix.record_map);
-                let pfx_rec = stored_prefix.record_map.as_public_records_vec();
+                let pfx_rec = stored_prefix.record_map.as_public_records();
                 // There is a prefix  here, but we need to check if it's
                 // the right one.
                 if self.cur_prefix_id

--- a/src/local_array/store/macros.rs
+++ b/src/local_array/store/macros.rs
@@ -101,7 +101,7 @@ macro_rules! retrieve_node_mut_with_guard_closure {
                             ).ok();
 
                             trace!("Retry_count rbm index {:?}", retry_count);
-                            println!("add multi uniq id to bitmap index {}", $multi_uniq_id);
+                            trace!("add multi uniq id to bitmap index {}", $multi_uniq_id);
                             return Some(SizedStrideRefMut::$stride(node));
                         };
                         // Meh, it's not, but we can a go to the next level

--- a/src/local_array/store/macros.rs
+++ b/src/local_array/store/macros.rs
@@ -8,49 +8,49 @@ macro_rules! impl_search_level {
         ),
     * ) => {
         $(
-            SearchLevel {
-                f: &|search_level: &SearchLevel<AF, $stride>,
-                    nodes,
-                    mut level: u8,
-                    guard| {
-                        // HASHING FUNCTION
-                        let index = Self::hash_node_id($id, level);
+        SearchLevel {
+            f: &|search_level: &SearchLevel<AF, $stride>,
+                nodes,
+                mut level: u8,
+                guard| {
+                    // HASHING FUNCTION
+                    let index = Self::hash_node_id($id, level);
 
-                        // Read the node from the block pointed to by the
-                        // Atomic pointer.
-                        let stored_node = unsafe {
-                            &mut nodes.0.load(Ordering::SeqCst, guard).deref()[index].assume_init_ref()
-                        };
-                        let this_node = stored_node.load(Ordering::Acquire, guard);
+                    // Read the node from the block pointed to by the Atomic
+                    // pointer.
+                    let stored_node = unsafe {
+                        &mut nodes.0.load(Ordering::SeqCst, guard).deref()[index].assume_init_ref()
+                    };
+                    let this_node = stored_node.load(Ordering::Acquire, guard);
 
-                        match this_node.is_null() {
-                            true => None,
-                            false => {
-                                let StoredNode { node_id, node, node_set, .. } = unsafe { this_node.deref() };
-                                if $id == *node_id {
-                                    // YES, It's the one we're looking for!
-                                    return Some(SizedStrideRef::$stride(&node));
-                                };
-                                // Meh, it's not, but we can a go to the next level
-                                // and see if it lives there.
-                                level += 1;
-                                match <NB as NodeBuckets<AF>>::len_to_store_bits($id.get_id().1, level) {
-                                    // on to the next level!
-                                    next_bit_shift if next_bit_shift > 0 => {
-                                        (search_level.f)(
-                                            search_level,
-                                            &node_set,
-                                            level,
-                                            guard,
-                                        )
-                                    }
-                                    // There's no next level, we found nothing.
-                                    _ => None,
+                    match this_node.is_null() {
+                        true => None,
+                        false => {
+                            let StoredNode { node_id, node, node_set, .. } = unsafe { this_node.deref() };
+                            if $id == *node_id {
+                                // YES, It's the one we're looking for!
+                                return Some(SizedStrideRef::$stride(&node));
+                            };
+                            // Meh, it's not, but we can a go to the next
+                            // level and see if it lives there.
+                            level += 1;
+                            match <NB as NodeBuckets<AF>>::len_to_store_bits($id.get_id().1, level) {
+                                // on to the next level!
+                                next_bit_shift if next_bit_shift > 0 => {
+                                    (search_level.f)(
+                                        search_level,
+                                        &node_set,
+                                        level,
+                                        guard,
+                                    )
                                 }
+                                // There's no next level, we found nothing.
+                                _ => None,
                             }
                         }
                     }
-            }
+                }
+        }
         )*
     };
 }
@@ -64,58 +64,67 @@ macro_rules! retrieve_node_mut_with_guard_closure {
             $id: ident;
             $multi_uniq_id: ident;
         ),
-    * ) => {
-        $(
-            SearchLevel {
-                f: &|search_level: &SearchLevel<AF, $stride>,
-                    nodes,
-                    mut level: u8,
-                    guard| {
+    * ) => {$(
+        SearchLevel {
+            f: &|
+                search_level: &SearchLevel<AF, $stride>,
+                nodes,
+                mut level: u8,
+                guard
+            | {
+                // HASHING FUNCTION
+                let index = Self::hash_node_id($id, level);
 
-                         // HASHING FUNCTION
-                         let index = Self::hash_node_id($id, level);
+                // Read the node from the block pointed to by the Atomic
+                // pointer.
+                let stored_node = unsafe {
+                    &mut nodes.0.load(Ordering::SeqCst, guard).deref_mut()[index].assume_init_ref()
+                };
+                let mut this_node = stored_node.load(Ordering::Acquire, guard);
 
-                         // Read the node from the block pointed to by the
-                         // Atomic pointer.
-                         let stored_node = unsafe {
-                             &mut nodes.0.load(Ordering::SeqCst, guard).deref_mut()[index].assume_init_ref()
-                         };
-                         let mut this_node = stored_node.load(Ordering::Acquire, guard);
+                match this_node.is_null() {
+                    true => None,
+                    false => {
+                        let StoredNode { node_id, node, node_set } = unsafe { this_node.deref_mut() };
+                        if $id == *node_id {
+                            // YES, It's the one we're looking for!
 
-                         match this_node.is_null() {
-                             true => None,
-                             false => {
-                                let StoredNode { node_id, node, node_set, rbm_index } = unsafe { this_node.deref_mut() };
-                                if $id == *node_id {
-                                    // YES, It's the one we're looking for!
-                                    rbm_index.insert($multi_uniq_id);
-                                    println!("add multi uniq id to bitmap index {}", $multi_uniq_id);
-                                    println!("index len {}", rbm_index.len());
-                                    return Some(SizedStrideRefMut::$stride(node));
-                                };
-                                // Meh, it's not, but we can a go to the next level
-                                // and see if it lives there.
-                                level += 1;
-                                match <NB as NodeBuckets<AF>>::len_to_store_bits($id.get_id().1, level) {
-                                    // on to the next level!
-                                    next_bit_shift if next_bit_shift > 0 => {
-                                        (search_level.f)(
-                                            search_level,
-                                            &node_set,
-                                            level,
-                                            guard,
-                                        )
-                                    }
-                                    // There's no next level, we found nothing.
-                                    _ => None,
-                                }
-                             }
+                            // Update the rbm_index in this node with the
+                            // multi_uniq_id that the caller specified. This
+                            // is the only atomic operation we need to do
+                            // here. The NodeSet that the index is attached
+                            // to, does not need to be written to, it's part
+                            // of a trie, so it just needs to "exist" (and it
+                            // already does).
+                            let retry_count = nodes.update_rbm_index(
+                                $multi_uniq_id, guard
+                            ).ok();
 
-                         }
+                            trace!("Retry_count rbm index {:?}", retry_count);
+                            println!("add multi uniq id to bitmap index {}", $multi_uniq_id);
+                            return Some(SizedStrideRefMut::$stride(node));
+                        };
+                        // Meh, it's not, but we can a go to the next level
+                        // and see if it lives there.
+                        level += 1;
+                        match <NB as NodeBuckets<AF>>::len_to_store_bits($id.get_id().1, level) {
+                            // on to the next level!
+                            next_bit_shift if next_bit_shift > 0 => {
+                                (search_level.f)(
+                                    search_level,
+                                    &node_set,
+                                    level,
+                                    guard,
+                                )
+                            }
+                            // There's no next level, we found nothing.
+                            _ => None,
+                        }
                     }
+                }
             }
-        )*
-    };
+        }
+    )*};
 }
 
 #[macro_export]
@@ -125,204 +134,197 @@ macro_rules! store_node_closure {
         $(
             $stride: ident;
             $id: ident;
-            $multi_uniq_id: ident;
+            // $multi_uniq_id: ident;
             $guard: ident;
             $back_off: ident;
         ),
     *) => {
         $(
-            SearchLevel {
-                f: &|
-                search_level: &SearchLevel<AF, $stride>,
-                nodes,
-                new_node: TreeBitMapNode<AF, $stride>,
-                mut level: u8,
-                mut retry_count: u32| {
-                    let this_level = <NB as NodeBuckets<AF>>::len_to_store_bits($id.get_id().1, level);
-                    trace!("{:032b}", $id.get_id().0);
-                    trace!("id {:?}", $id.get_id());
+        SearchLevel {
+            f: &|
+            search_level: &SearchLevel<AF, $stride>,
+            nodes,
+            new_node: TreeBitMapNode<AF, $stride>,
+            multi_uniq_id: u32,
+            mut level: u8,
+            mut retry_count: u32| {
+                let this_level = <NB as NodeBuckets<AF>>::len_to_store_bits($id.get_id().1, level);
+                trace!("{:032b}", $id.get_id().0);
+                trace!("id {:?}", $id.get_id());
+                trace!("multi_uniq_id {}", multi_uniq_id);
 
-                    // HASHING FUNCTION
-                    let index = Self::hash_node_id($id, level);
-                    let stored_nodes = nodes.0.load(Ordering::Acquire, $guard);
+                // HASHING FUNCTION
+                let index = Self::hash_node_id($id, level);
+                let stored_nodes = nodes.0.load(Ordering::Acquire, $guard);
 
-                    match stored_nodes.is_null() {
-                        false => {
-                            let node_ref =
-                                unsafe { stored_nodes.deref()[index].assume_init_ref() };
-                            let stored_node = node_ref.load(Ordering::Acquire, $guard);
+                match stored_nodes.is_null() {
+                    false => {
+                        let node_ref =
+                            unsafe { stored_nodes.deref()[index].assume_init_ref() };
+                        let stored_node = node_ref.load(Ordering::Acquire, $guard);
 
-                            match stored_node.is_null() {
-                                true => {
-                                    // No node exists, so we create one here.
-                                    let next_level = <NB as NodeBuckets<AF>>::len_to_store_bits($id.get_id().1, level + 1);
+                        match stored_node.is_null() {
+                            true => {
+                                // No node exists, so we create one here.
+                                let next_level = <NB as NodeBuckets<AF>>::len_to_store_bits($id.get_id().1, level + 1);
 
-                                    if log_enabled!(log::Level::Trace) {
-                                        trace!("Empty node found, creating new node {} len{} lvl{}",
-                                            $id, $id.get_id().1, level + 1
-                                        );
-                                        trace!("Next level {}",
-                                            next_level
-                                        );
-                                        trace!("Creating space for {} nodes",
-                                            if next_level >= this_level { 1 << (next_level - this_level) } else { 1 }
-                                        );
-                                    }
-
-                                    let node_set = if next_level > 0 { 
-                                        NodeSet::init((1 << (next_level - this_level)) as usize )
-                                    } else { NodeSet(Atomic::null()) };
-
-                                    let mut rbm_index = RoaringBitmap::new();
-                                    rbm_index.insert($multi_uniq_id);
-                                    trace!("multi uniq id {}", $multi_uniq_id);
-                                    trace!("Add id to bitmap index {:?}", rbm_index);
-                                    trace!("bitmap index len {}", rbm_index.len());
-
-                                    match node_ref.compare_exchange(
-                                        Shared::null(),
-                                        Owned::new(StoredNode {
-                                            node_id: $id,
-                                            node: new_node,
-                                            node_set,
-                                            rbm_index
-                                        }),
-                                        Ordering::AcqRel,
-                                        Ordering::Acquire,
-                                        $guard
-                                    ) {
-                                        Ok(_pfx) => {
-
-                                            if log_enabled!(log::Level::Trace) {
-                                                trace!("Created node {}", $id);
-                                            }
-                                            return Ok(($id, retry_count));
-                                        },
-                                        Err(crossbeam_epoch::CompareExchangeError { new, .. }) => {
-                                            retry_count +=1 ;
-
-                                            if log_enabled!(log::Level::Trace) {
-                                                trace!("Failed to create node {}. Someone is busy creating it",$id);
-                                            }
-
-                                            let StoredNode { node: cur_node,.. } = *new.into_box();
-                                            $back_off.spin();
-                                            return (search_level.f)(
-                                                search_level,
-                                                nodes,
-                                                cur_node,
-                                                level,
-                                                retry_count
-                                            );
-                                        }
-                                    };
+                                if log_enabled!(log::Level::Trace) {
+                                    trace!("Empty node found, creating new node {} len{} lvl{}",
+                                        $id, $id.get_id().1, level + 1
+                                    );
+                                    trace!("Next level {}",
+                                        next_level
+                                    );
+                                    trace!("Creating space for {} nodes",
+                                        if next_level >= this_level { 1 << (next_level - this_level) } else { 1 }
+                                    );
                                 }
-                                false => {
-                                    // A node exists, might be ours, might be
-                                    // another one. SAFETY: We tested for null
-                                    // above and, since we do not remove
-                                    // nodes, this node can't be null anymore.
-                                    let stored_node = unsafe { stored_node.deref() };
 
-                                    if log_enabled!(log::Level::Trace) {
-                                        trace!("
-                                            {} store: Node here exists {:?}",
-                                                std::thread::current().name().unwrap(),
-                                                stored_node.node_id
-                                        );
-                                        trace!("node_id {:?}", stored_node.node_id.get_id());
-                                        trace!("node_id {:032b}", stored_node.node_id.get_id().0);
-                                        trace!("id {}", $id);
-                                        trace!("     id {:032b}", $id.get_id().0);
-                                    }
+                                // Update the rbm_index in this node with the
+                                // multi_uniq_id that the caller specified. We're
+                                // doing this independently from setting the
+                                // NodeSet atomically. If we would have done this
+                                // in one Atomic CAS operation we would have to
+                                // clone the NodeSet. Now we only have to clone
+                                // the rbm_index itself. Furthermore, these
+                                // operations can be (semi-)independent. Two
+                                // out-of-order things can happen:
+                                // 1. The rbm_index storing and the NodeSet
+                                // storing get interjected with rbm_index value
+                                // from another thread. In that case the whole
+                                // NodeSet storing operation fails and is retried
+                                // with a newly acquired value for both the
+                                // rbm_index and the NodeSet.
+                                // 2. The rmb_index storing operation succeeds,
+                                // but the NodeSet storing operation fails,
+                                // because the contention retries hit the
+                                // threshold. In that case a false positive is
+                                // stored in the index, which leads to more
+                                // in-vain searching, but not to data corruption.
+                                retry_count += nodes.update_rbm_index(
+                                    multi_uniq_id, $guard
+                                )?;
 
-                                    // See if somebody beat us to creating our
-                                    // node already, if so, we still need to
-                                    // do work: we have to update the bitmap
-                                    // index with the multi_uniq_id we've got
-                                    // from the caller.
-                                    if $id == stored_node.node_id {
-                                        // yes, it exists
-                                        trace!("found node {} in {} attempts",
-                                            $id,
+                                trace!("multi uniq id {}", multi_uniq_id);
+
+                                let node_set = if next_level > 0 { 
+                                    NodeSet::init((1 << (next_level - this_level)) as usize )
+                                } else { NodeSet(
+                                    Atomic::null(), nodes.1.load(Ordering::Acquire, $guard).into()) };
+
+                                match node_ref.compare_exchange(
+                                    Shared::null(),
+                                    Owned::new(StoredNode {
+                                        node_id: $id,
+                                        node: new_node,
+                                        node_set,
+                                    }),
+                                    Ordering::AcqRel,
+                                    Ordering::Acquire,
+                                    $guard
+                                ) {
+                                    Ok(_pfx) => {
+
+                                        if log_enabled!(log::Level::Trace) {
+                                            trace!("Created node {}", $id);
+                                        }
+                                        return Ok(($id, retry_count));
+                                    },
+                                    Err(crossbeam_epoch::CompareExchangeError { new, .. }) => {
+                                        retry_count +=1 ;
+
+                                        if log_enabled!(log::Level::Trace) {
+                                            trace!("Failed to create node {}. Someone is busy creating it",$id);
+                                        }
+
+                                        let StoredNode { node: cur_node,.. } = *new.into_box();
+                                        $back_off.spin();
+                                        return (search_level.f)(
+                                            search_level,
+                                            nodes,
+                                            cur_node,
+                                            multi_uniq_id,
+                                            level,
                                             retry_count
                                         );
-                                        let mut rbm_index = stored_node.rbm_index.clone();
-                                        rbm_index.insert($multi_uniq_id);
+                                    }
+                                };
+                            }
+                            false => {
+                                // A node exists, might be ours, might be
+                                // another one. SAFETY: We tested for null
+                                // above and, since we do not remove nodes,
+                                // this node can't be null anymore.
+                                let stored_node = unsafe { stored_node.deref() };
 
-                                        match node_ref.compare_exchange(
-                                            Shared::null(),
-                                            Owned::new(StoredNode {
-                                                node_id: $id,
-                                                node: new_node,
-                                                node_set: stored_node.node_set.clone(),
-                                                rbm_index
-                                            }),
-                                            Ordering::AcqRel,
-                                            Ordering::Acquire,
-                                            $guard
-                                        ) {
-                                            Ok(_pfx) => {
-    
-                                                if log_enabled!(log::Level::Trace) {
-                                                    trace!("Created node {}", $id);
-                                                }
-                                                return Ok(($id, retry_count));
-                                            },
-                                            Err(crossbeam_epoch::CompareExchangeError { new, .. }) => {
-                                                retry_count +=1 ;
-    
-                                                if log_enabled!(log::Level::Trace) {
-                                                    trace!("Failed to create node {}. Someone is busy creating it",$id);
-                                                }
-    
-                                                let StoredNode { node: cur_node,.. } = *new.into_box();
-                                                $back_off.spin();
-                                                return (search_level.f)(
-                                                    search_level,
-                                                    nodes,
-                                                    cur_node,
-                                                    level,
-                                                    retry_count
-                                                );
-                                            }
-                                        };
-                                    } else {
-                                        // it's not "our" node, make a
-                                        // (recursive) call to create it.
-                                        level += 1;
-                                        trace!("Collision with node_id {}, move to next level: {} len{} next_lvl{} index {}",
-                                            stored_node.node_id, $id, $id.get_id().1, level, index
-                                        );                                        
+                                if log_enabled!(log::Level::Trace) {
+                                    trace!("
+                                        {} store: Node here exists {:?}",
+                                            std::thread::current().name().unwrap(),
+                                            stored_node.node_id
+                                    );
+                                    trace!("node_id {:?}", stored_node.node_id.get_id());
+                                    trace!("node_id {:032b}", stored_node.node_id.get_id().0);
+                                    trace!("id {}", $id);
+                                    trace!("     id {:032b}", $id.get_id().0);
+                                }
 
-                                        return match <NB as NodeBuckets<AF>>::len_to_store_bits($id.get_id().1, level) {
-                                            // on to the next level!
-                                            next_bit_shift if next_bit_shift > 0 => {
-                                                (search_level.f)(
-                                                    search_level,
-                                                    &stored_node.node_set,
-                                                    new_node,
-                                                    level,
-                                                    retry_count
-                                                )
-                                            }
-                                            // There's no next level!
-                                            _ => panic!("out of storage levels, current level is {}", level),
+                                // See if somebody beat us to creating our
+                                // node already, if so, we still need to do
+                                // work: we have to update the bitmap index
+                                // with the multi_uniq_id we've got from the
+                                // caller.
+                                if $id == stored_node.node_id {
+                                    // yes, it exists
+                                    trace!("found node {} in {} attempts",
+                                        $id,
+                                        retry_count
+                                    );
+
+                                    // Same remarks here as the above
+                                    // fetch_update.
+                                    nodes.update_rbm_index(
+                                        multi_uniq_id, $guard
+                                    )?;
+
+                                    return Ok(($id, retry_count));
+                                } else {
+                                    // it's not "our" node, make a (recursive)
+                                    // call to create it.
+                                    level += 1;
+                                    trace!("Collision with node_id {}, move to next level: {} len{} next_lvl{} index {}",
+                                        stored_node.node_id, $id, $id.get_id().1, level, index
+                                    );                                        
+
+                                    return match <NB as NodeBuckets<AF>>::len_to_store_bits($id.get_id().1, level) {
+                                        // on to the next level!
+                                        next_bit_shift if next_bit_shift > 0 => {
+                                            (search_level.f)(
+                                                search_level,
+                                                &stored_node.node_set,
+                                                new_node,
+                                                multi_uniq_id,
+                                                level,
+                                                retry_count
+                                            )
                                         }
+                                        // There's no next level!
+                                        _ => panic!("out of storage levels, current level is {}", level),
                                     }
                                 }
                             }
                         }
-                        true => {
-                            trace!("Empty node set for {} in {} attempts. Giving up.",
-                                $id,
-                                retry_count
-                            );
-                            return Err(super::errors::PrefixStoreError::NodeNotFound);
-                        }
-                    };
-                }
+                    }
+                    true => {
+                        trace!("Empty node set for {} in {} attempts. Giving up.",
+                            $id,
+                            retry_count
+                        );
+                        return Err(super::errors::PrefixStoreError::NodeNotFound);
+                    }
+                };
             }
+        }
         )*
     };
 }

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -9,12 +9,11 @@ use std::sync::atomic::{
 use std::{fmt::Debug, marker::PhantomData};
 
 use crate::af::AddressFamily;
-use crate::custom_alloc::{CustomAllocStorage, Upsert, UpsertReport};
+use crate::custom_alloc::{CustomAllocStorage, UpsertReport};
 use crate::insert_match;
 use crate::local_array::store::atomic_types::{NodeBuckets, PrefixBuckets};
 
 pub(crate) use super::atomic_stride::*;
-use super::store::atomic_types::{MultiMapValue, RouteStatus};
 use super::store::errors::PrefixStoreError;
 
 pub(crate) use crate::local_array::node::TreeBitMapNode;
@@ -487,8 +486,6 @@ impl<
             let node_result = insert_match![
                 // applicable to the whole outer match in the macro
                 self;
-                user_data;
-                // multi_uniq_id;
                 guard;
                 nibble_len;
                 nibble;

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -1,4 +1,4 @@
-use crate::prefix_record::{MergeUpdate, Meta, PublicRecord};
+use crate::prefix_record::{Meta, PublicRecord};
 use crossbeam_epoch::{self as epoch};
 use log::{error, log_enabled, trace};
 
@@ -360,7 +360,7 @@ impl std::fmt::Display for StrideType {
 
 pub struct TreeBitMap<
     AF: AddressFamily,
-    M: Meta + MergeUpdate,
+    M: Meta,
     NB: NodeBuckets<AF>,
     PB: PrefixBuckets<AF, M>,
 > {
@@ -370,7 +370,7 @@ pub struct TreeBitMap<
 impl<
         'a,
         AF: AddressFamily,
-        M: Meta + MergeUpdate,
+        M: Meta,
         NB: NodeBuckets<AF>,
         PB: PrefixBuckets<AF, M>,
     > TreeBitMap<AF, M, NB, PB>
@@ -659,7 +659,7 @@ impl<
 
 impl<
         AF: AddressFamily,
-        M: Meta + MergeUpdate,
+        M: Meta,
         NB: NodeBuckets<AF>,
         PB: PrefixBuckets<AF, M>,
     > Default for TreeBitMap<AF, M, NB, PB>
@@ -673,7 +673,7 @@ impl<
 #[cfg(feature = "cli")]
 impl<
         AF: AddressFamily,
-        M: Meta + MergeUpdate,
+        M: Meta,
         NB: NodeBuckets<AF>,
         PB: PrefixBuckets<AF, M>,
     > std::fmt::Display for TreeBitMap<AF, M, NB, PB>

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -562,6 +562,21 @@ impl<
         // user_data: Option<&<M as MergeUpdate>::UserDataIn>,
     ) -> Result<UpsertReport, PrefixStoreError> {
         trace!("Updating the default route...");
+
+        if let Some(root_node) = self.store.retrieve_node_mut_with_guard(self.store.get_root_node_id(), record.multi_uniq_id, guard) {
+            match root_node {
+                SizedStrideRefMut::Stride3(_) => { 
+                    self.store.buckets.get_store3(self.store.get_root_node_id()).update_rbm_index(record.multi_uniq_id, guard)?;
+                },
+                SizedStrideRefMut::Stride4(_) => {
+                    self.store.buckets.get_store4(self.store.get_root_node_id()).update_rbm_index(record.multi_uniq_id, guard)?;
+                },
+                SizedStrideRefMut::Stride5(_) => {
+                    self.store.buckets.get_store5(self.store.get_root_node_id()).update_rbm_index(record.multi_uniq_id, guard)?;
+                 },
+            };
+        };
+        
         self.store.upsert_prefix(
             PrefixId::new(AF::zero(), 0),
             record,

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -481,7 +481,6 @@ impl<
             let is_last_stride = pfx.get_len() <= stride_end;
             let stride_start = stride_end - stride;
             let back_off = crossbeam_utils::Backoff::new();
-            let multi_uniq_id = record.multi_uniq_id;
 
             // insert_match! returns the node_id of the next node to be
             // traversed. It was created if it did not exist.

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -448,14 +448,14 @@ impl<
         &self,
         pfx: PrefixId<AF>,
         record: PublicRecord<M>,
-        user_data: Option<&<M as MergeUpdate>::UserDataIn>,
+        // user_data: Option<&<M as MergeUpdate>::UserDataIn>,
     ) -> Result<UpsertReport, PrefixStoreError> {
         let guard = &epoch::pin();
         // let record = MultiMapValue::new(meta, ltime, status);
 
         if pfx.get_len() == 0 {
             let res = self.update_default_route_prefix_meta(
-                record, guard, user_data)?;
+                record, guard)?;
             return Ok(res);
         }
 
@@ -561,14 +561,14 @@ impl<
         &self,
         record: PublicRecord<M>,
         guard: &epoch::Guard,
-        user_data: Option<&<M as MergeUpdate>::UserDataIn>,
+        // user_data: Option<&<M as MergeUpdate>::UserDataIn>,
     ) -> Result<UpsertReport, PrefixStoreError> {
         trace!("Updating the default route...");
         self.store.upsert_prefix(
             PrefixId::new(AF::zero(), 0),
             record,
             guard,
-            user_data,
+            // user_data,
         )
     }
 

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -1,6 +1,6 @@
 use crate::prefix_record::{Meta, PublicRecord};
 use crossbeam_epoch::{self as epoch};
-use log::{error, log_enabled, trace};
+use log::{error, log_enabled, trace, debug};
 
 use std::hash::Hash;
 use std::sync::atomic::{

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -321,12 +321,12 @@ impl<AF: AddressFamily> std::convert::From<AtomicStrideNodeId<AF>> for usize {
 
 //------------------------- Node Collections --------------------------------
 
-pub trait NodeCollection<AF: AddressFamily> {
-    fn insert(&mut self, index: u16, insert_node: StrideNodeId<AF>);
-    fn to_vec(&self) -> Vec<StrideNodeId<AF>>;
-    fn as_slice(&self) -> &[AtomicStrideNodeId<AF>];
-    fn empty() -> Self;
-}
+// pub trait NodeCollection<AF: AddressFamily> {
+//     fn insert(&mut self, index: u16, insert_node: StrideNodeId<AF>);
+//     fn to_vec(&self) -> Vec<StrideNodeId<AF>>;
+//     fn as_slice(&self) -> &[AtomicStrideNodeId<AF>];
+//     fn empty() -> Self;
+// }
 
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Copy, Clone)]
 pub enum StrideType {
@@ -655,10 +655,7 @@ impl<
         nibble: u32,
         nibble_len: u8,
         base_prefix: StrideNodeId<AF>,
-    ) -> Option<Vec<PrefixId<AF>>>
-    where
-        S: Stride,
-    {
+    ) -> Option<Vec<PrefixId<AF>>> {
         let (cnvec, mut msvec) = current_node.add_more_specifics_at(
             nibble,
             nibble_len,

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -1,6 +1,7 @@
 use crate::prefix_record::{Meta, PublicRecord};
 use crossbeam_epoch::{self as epoch};
 use log::{error, log_enabled, trace, debug};
+use routecore::bgp::path_selection::TiebreakerInfo;
 
 use std::hash::Hash;
 use std::sync::atomic::{
@@ -9,7 +10,7 @@ use std::sync::atomic::{
 use std::{fmt::Debug, marker::PhantomData};
 
 use crate::af::AddressFamily;
-use crate::custom_alloc::{CustomAllocStorage, TieBreakerInfo, UpsertReport};
+use crate::custom_alloc::{CustomAllocStorage, UpsertReport};
 use crate::insert_match;
 use crate::local_array::store::atomic_types::{NodeBuckets, PrefixBuckets};
 
@@ -447,7 +448,7 @@ impl<
         &self,
         pfx: PrefixId<AF>,
         record: PublicRecord<M>,
-        update_path_selections: Option<TieBreakerInfo>,
+        update_path_selections: Option<M::TBI>,
         // user_data: Option<&<M as MergeUpdate>::UserDataIn>,
     ) -> Result<UpsertReport, PrefixStoreError> {
         let guard = &epoch::pin();

--- a/src/local_array/tree.rs
+++ b/src/local_array/tree.rs
@@ -447,6 +447,7 @@ impl<
         &self,
         pfx: PrefixId<AF>,
         record: M,
+        multi_uniq_id: u32,
         user_data: Option<&<M as MergeUpdate>::UserDataIn>,
     ) -> Result<(Upsert<<M as MergeUpdate>::UserDataOut>, u32), PrefixStoreError> {
         let guard = &epoch::pin();
@@ -485,6 +486,7 @@ impl<
                 // applicable to the whole outer match in the macro
                 self;
                 user_data;
+                multi_uniq_id;
                 guard;
                 nibble_len;
                 nibble;

--- a/src/local_vec/macros.rs
+++ b/src/local_vec/macros.rs
@@ -8,7 +8,7 @@
 macro_rules! match_node_for_strides_with_local_vec {
     (
         $self: ident;
-        $user_data: ident;
+        // $user_data: ident;
         $nibble_len: expr;
         $nibble: expr;
         $is_last_stride: expr;
@@ -83,7 +83,7 @@ macro_rules! match_node_for_strides_with_local_vec {
                     // so we can return from here.
                     // If we don't then we cannot move pfx.meta into the update_prefix_meta function,
                     // since the compiler can't figure out that it will happen only once.
-                    $self.update_prefix_meta(pfx_idx, $pfx.meta, $user_data)?;
+                    $self.update_prefix_meta(pfx_idx, $pfx.meta)?;
                     $self.store.update_node($cur_i,SizedStrideNode::$variant(current_node));
 
                     // let _default_val = std::mem::replace(

--- a/src/local_vec/query.rs
+++ b/src/local_vec/query.rs
@@ -87,7 +87,7 @@ impl<M: crate::prefix_record::Meta> std::fmt::Display
             Some(pfx) => format!("{}", pfx),
             None => "".to_string(),
         };
-        write!(
+        writeln!(
             f,
             "match_type: {}\nprefix: {}\nmetadata: {}\nless_specifics: {}\nmore_specifics: {}",
             self.match_type,

--- a/src/local_vec/storage_backend.rs
+++ b/src/local_vec/storage_backend.rs
@@ -4,7 +4,7 @@ use crate::prefix_record::InternalPrefixRecord;
 use crate::local_vec::tree::*;
 
 use crate::af::AddressFamily;
-use crate::prefix_record::MergeUpdate;
+// use crate::prefix_record::MergeUpdate;
 
 use std::fmt::Debug;
 use std::io::{Error, ErrorKind};
@@ -20,7 +20,7 @@ where
 {
     type NodeType;
     type AF: AddressFamily;
-    type Meta: crate::prefix_record::Meta + MergeUpdate;
+    type Meta: crate::prefix_record::Meta;
 
     fn init(
         start_node: Option<SizedStrideNode<Self::AF, Self::NodeType>>,
@@ -98,7 +98,7 @@ pub(crate) struct InMemStorage<
     pub prefixes: Vec<InternalPrefixRecord<AF, Meta>>,
 }
 
-impl<AF: AddressFamily, Meta: crate::prefix_record::Meta + MergeUpdate>
+impl<AF: AddressFamily, Meta: crate::prefix_record::Meta>
     StorageBackend for InMemStorage<AF, Meta>
 {
     type NodeType = InMemNodeId;

--- a/src/local_vec/storage_backend.rs
+++ b/src/local_vec/storage_backend.rs
@@ -9,10 +9,10 @@ use crate::af::AddressFamily;
 use std::fmt::Debug;
 use std::io::{Error, ErrorKind};
 
-pub(crate) type PrefixIter<'a, AF, Meta> = Result<
-    std::slice::Iter<'a, InternalPrefixRecord<AF, Meta>>,
-    Box<dyn std::error::Error>,
->;
+// pub(crate) type PrefixIter<'a, AF, Meta> = Result<
+//     std::slice::Iter<'a, InternalPrefixRecord<AF, Meta>>,
+//     Box<dyn std::error::Error>,
+// >;
 
 pub(crate) trait StorageBackend
 where
@@ -48,15 +48,15 @@ where
         &mut self,
         index: Self::NodeType,
     ) -> SizedNodeResult<Self::AF, Self::NodeType>;
-    fn retrieve_node_with_guard(
+    fn _retrieve_node_with_guard(
         &self,
         index: Self::NodeType,
     ) -> CacheGuard<Self::AF, Self::NodeType>;
     fn get_root_node_id(&self) -> Self::NodeType;
-    fn get_root_node_mut(
+    fn _get_root_node_mut(
         &mut self,
     ) -> Option<&mut SizedStrideNode<Self::AF, Self::NodeType>>;
-    fn get_nodes(&self) -> &Vec<SizedStrideNode<Self::AF, Self::NodeType>>;
+    fn _get_nodes(&self) -> &Vec<SizedStrideNode<Self::AF, Self::NodeType>>;
     fn get_nodes_len(&self) -> usize;
     fn acquire_new_prefix_id(
         &self,
@@ -78,15 +78,16 @@ where
         &mut self,
         index: <<Self as StorageBackend>::NodeType as SortableNodeId>::Part,
     ) -> Option<&mut InternalPrefixRecord<Self::AF, Self::Meta>>;
-    fn retrieve_prefix_with_guard(
+    fn _retrieve_prefix_with_guard(
         &self,
         index: Self::NodeType,
     ) -> PrefixCacheGuard<Self::AF, Self::Meta>;
-    fn get_prefixes(
+    fn _get_prefixes(
         &self,
     ) -> &Vec<InternalPrefixRecord<Self::AF, Self::Meta>>;
+    #[cfg(feature = "cli")]
     fn get_prefixes_len(&self) -> usize;
-    fn prefixes_iter(&self) -> PrefixIter<'_, Self::AF, Self::Meta>;
+    // fn prefixes_iter(&self) -> PrefixIter<'_, Self::AF, Self::Meta>;
 }
 
 #[derive(Debug)]
@@ -172,7 +173,7 @@ impl<AF: AddressFamily, Meta: crate::prefix_record::Meta>
 
     // Don't use this function, this is just a placeholder and a really
     // inefficient implementation.
-    fn retrieve_node_with_guard(
+    fn _retrieve_node_with_guard(
         &self,
         _id: Self::NodeType,
     ) -> CacheGuard<Self::AF, Self::NodeType> {
@@ -183,13 +184,13 @@ impl<AF: AddressFamily, Meta: crate::prefix_record::Meta>
         InMemNodeId(0, 0)
     }
 
-    fn get_root_node_mut(
+    fn _get_root_node_mut(
         &mut self,
     ) -> Option<&mut SizedStrideNode<Self::AF, Self::NodeType>> {
         Some(&mut self.nodes[0])
     }
 
-    fn get_nodes(&self) -> &Vec<SizedStrideNode<Self::AF, Self::NodeType>> {
+    fn _get_nodes(&self) -> &Vec<SizedStrideNode<Self::AF, Self::NodeType>> {
         &self.nodes
     }
 
@@ -233,26 +234,27 @@ impl<AF: AddressFamily, Meta: crate::prefix_record::Meta>
         self.prefixes.get_mut(index as usize)
     }
 
-    fn retrieve_prefix_with_guard(
+    fn _retrieve_prefix_with_guard(
         &self,
         _index: Self::NodeType,
     ) -> PrefixCacheGuard<Self::AF, Self::Meta> {
         panic!("nOt ImPlEmEnTed for InMemNode");
     }
 
-    fn get_prefixes(
+    fn _get_prefixes(
         &self,
     ) -> &Vec<InternalPrefixRecord<Self::AF, Self::Meta>> {
         &self.prefixes
     }
 
+    #[cfg(feature = "cli")]
     fn get_prefixes_len(&self) -> usize {
         self.prefixes.len()
     }
 
-    fn prefixes_iter(
-        &self,
-    ) -> PrefixIter<'_, AF, Meta> {
-        Ok(self.prefixes.iter())
-    }
+    // fn prefixes_iter(
+    //     &self,
+    // ) -> PrefixIter<'_, AF, Meta> {
+    //     Ok(self.prefixes.iter())
+    // }
 }

--- a/src/local_vec/store.rs
+++ b/src/local_vec/store.rs
@@ -2,7 +2,7 @@ use crate::local_vec::storage_backend::{InMemStorage, StorageBackend};
 use crate::local_vec::TreeBitMap;
 use crate::node_id::InMemNodeId;
 use crate::prefix_record::InternalPrefixRecord;
-use super::query::QueryResult;
+use super::query::QuerySingleResult;
 use crate::{MatchOptions, Stats, Strides};
 
 use crate::af::{IPv4, IPv6};
@@ -38,7 +38,7 @@ impl<'a, M: crate::prefix_record::Meta + MergeUpdate> Store<M> {
         &'a self,
         search_pfx: &Prefix,
         options: &MatchOptions,
-    ) -> QueryResult<M> {
+    ) -> QuerySingleResult<M> {
         match search_pfx.addr() {
             std::net::IpAddr::V4(addr) => self.v4.match_prefix(
                 PrefixId::<IPv4>::new(addr.into(), search_pfx.len()),
@@ -77,12 +77,12 @@ impl<'a, M: crate::prefix_record::Meta + MergeUpdate> Store<M> {
         }
     }
 
-    pub fn prefixes_iter(&'a self) -> crate::PrefixRecordIter<'a, M> {
+    pub fn prefixes_iter(&'a self) -> crate::PrefixSingleRecordIter<'a, M> {
         let rs4: std::slice::Iter<InternalPrefixRecord<IPv4, M>> =
             self.v4.store.prefixes[..].iter();
         let rs6 = self.v6.store.prefixes[..].iter();
 
-        crate::PrefixRecordIter::<'a, M> {
+        crate::PrefixSingleRecordIter::<'a, M> {
             v4: Some(rs4),
             v6: rs6,
         }

--- a/src/local_vec/store.rs
+++ b/src/local_vec/store.rs
@@ -7,7 +7,6 @@ use crate::{MatchOptions, Stats, Strides};
 
 use crate::af::{IPv4, IPv6};
 use inetnum::addr::Prefix;
-use crate::prefix_record::MergeUpdate;
 
 use super::query::PrefixId;
 use super::tree::SizedStrideNode;
@@ -16,15 +15,12 @@ use super::tree::SizedStrideNode;
 /// Can be used in multi-threaded contexts by wrapping it in a `Arc<Mutex<_>>`.
 /// Be aware that this is undesirable in cases with high contention.
 /// Use cases with high contention are best served by the [`crate::MultiThreadedStore`].
-pub struct Store<M: crate::prefix_record::Meta>
-where
-    M: MergeUpdate,
-{
+pub struct Store<M: crate::prefix_record::Meta> {
     v4: TreeBitMap<InMemStorage<IPv4, M>>,
     v6: TreeBitMap<InMemStorage<IPv6, M>>,
 }
 
-impl<M: crate::prefix_record::Meta + MergeUpdate> Store<M> {
+impl<M: crate::prefix_record::Meta> Store<M> {
     pub fn new(v4_strides: Vec<u8>, v6_strides: Vec<u8>) -> Self {
         Store {
             v4: TreeBitMap::new(v4_strides),
@@ -33,7 +29,7 @@ impl<M: crate::prefix_record::Meta + MergeUpdate> Store<M> {
     }
 }
 
-impl<'a, M: crate::prefix_record::Meta + MergeUpdate> Store<M> {
+impl<'a, M: crate::prefix_record::Meta> Store<M> {
     pub fn match_prefix(
         &'a self,
         search_pfx: &Prefix,
@@ -55,7 +51,7 @@ impl<'a, M: crate::prefix_record::Meta + MergeUpdate> Store<M> {
         &mut self,
         prefix: &Prefix,
         meta: M,
-        user_data: Option<&<M as MergeUpdate>::UserDataIn>,
+        // user_data: Option<&<M>::UserDataIn>,
     ) -> Result<(), std::boxed::Box<dyn std::error::Error>> {
         match prefix.addr() {
             std::net::IpAddr::V4(addr) => {
@@ -63,16 +59,14 @@ impl<'a, M: crate::prefix_record::Meta + MergeUpdate> Store<M> {
                     addr.into(),
                     prefix.len(),
                     meta,
-                ),
-                user_data)
+                ))
             }
             std::net::IpAddr::V6(addr) => {
                 self.v6.insert(InternalPrefixRecord::new_with_meta(
                     addr.into(),
                     prefix.len(),
                     meta,
-                ),
-                user_data)
+                ))
             }
         }
     }

--- a/src/local_vec/tests/full_table_single.rs
+++ b/src/local_vec/tests/full_table_single.rs
@@ -13,32 +13,32 @@ mod full_table {
     #[derive(Debug, Clone)]
     pub struct ComplexPrefixAs(pub Vec<u32>);
 
-    impl MergeUpdate for ComplexPrefixAs {
-        type UserDataIn = ();
-        type UserDataOut = ();
+    // impl MergeUpdate for ComplexPrefixAs {
+    //     type UserDataIn = ();
+    //     type UserDataOut = ();
 
-        fn merge_update(
-            &mut self,
-            update_record: ComplexPrefixAs,
-            _: Option<&Self::UserDataIn>,
-        ) -> Result<(), Box<dyn std::error::Error>> {
-            self.0 = update_record.0;
-            Ok(())
-        }
+    //     fn merge_update(
+    //         &mut self,
+    //         update_record: ComplexPrefixAs,
+    //         _: Option<&Self::UserDataIn>,
+    //     ) -> Result<(), Box<dyn std::error::Error>> {
+    //         self.0 = update_record.0;
+    //         Ok(())
+    //     }
 
-        fn clone_merge_update(
-            &self,
-            update_meta: &Self,
-            _: Option<&Self::UserDataIn>,
-        ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
-        where
-            Self: std::marker::Sized,
-        {
-            let mut new_meta = update_meta.0.clone();
-            new_meta.push(self.0[0]);
-            Ok((ComplexPrefixAs(new_meta), ()))
-        }
-    }
+    //     fn clone_merge_update(
+    //         &self,
+    //         update_meta: &Self,
+    //         _: Option<&Self::UserDataIn>,
+    //     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
+    //     where
+    //         Self: std::marker::Sized,
+    //     {
+    //         let mut new_meta = update_meta.0.clone();
+    //         new_meta.push(self.0[0]);
+    //         Ok((ComplexPrefixAs(new_meta), ()))
+    //     }
+    // }
 
     impl std::fmt::Display for ComplexPrefixAs {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -99,7 +99,7 @@ mod full_table {
 
             let inserts_num = pfxs.len();
             for pfx in pfxs.into_iter() {
-                match tree_bitmap.insert(&pfx.prefix, pfx.meta, None) {
+                match tree_bitmap.insert(&pfx.prefix, pfx.meta) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/src/local_vec/tests/full_table_single.rs
+++ b/src/local_vec/tests/full_table_single.rs
@@ -3,7 +3,7 @@
     
 mod full_table {    
     use crate::{
-        prelude::*, SingleThreadedStore,
+        prelude::*, PublicPrefixSingleRecord, SingleThreadedStore
     };
 
     use std::error::Error;
@@ -57,7 +57,7 @@ mod full_table {
         const FOUND_PREFIXES: u32 = 1322993;
 
         fn load_prefixes(
-            pfxs: &mut Vec<PrefixRecord<ComplexPrefixAs>>,
+            pfxs: &mut Vec<PublicPrefixSingleRecord<ComplexPrefixAs>>,
         ) -> Result<(), Box<dyn Error>> {
             let file = File::open(CSV_FILE_PATH)?;
 
@@ -71,7 +71,7 @@ mod full_table {
                 let net = std::net::Ipv4Addr::new(ip[0], ip[1], ip[2], ip[3]);
                 let len: u8 = record[1].parse().unwrap();
                 let asn: u32 = record[2].parse().unwrap();
-                let pfx = PrefixRecord::new(
+                let pfx = PublicPrefixSingleRecord::new(
                     Prefix::new(net.into(), len)?,
                     ComplexPrefixAs(vec![asn]),
                 );
@@ -87,7 +87,7 @@ mod full_table {
             // vec![3, 4, 4, 6, 7, 8],
         ];
         for _strides in strides_vec.iter().enumerate() {
-            let mut pfxs: Vec<PrefixRecord<ComplexPrefixAs>> = vec![];
+            let mut pfxs: Vec<PublicPrefixSingleRecord<ComplexPrefixAs>> = vec![];
             let v4_strides = vec![8];
             let v6_strides = vec![8];
             let mut tree_bitmap = SingleThreadedStore::<ComplexPrefixAs>::new(v4_strides, v6_strides);

--- a/src/local_vec/tests/full_table_single.rs
+++ b/src/local_vec/tests/full_table_single.rs
@@ -2,6 +2,9 @@
 #![cfg(test)]
     
 mod full_table {    
+    use inetnum::asn::Asn;
+    use routecore::bgp::path_selection::{Rfc4271, TiebreakerInfo};
+
     use crate::{
         prelude::*, PublicPrefixSingleRecord, SingleThreadedStore
     };
@@ -10,7 +13,7 @@ mod full_table {
     use std::fs::File;
     use std::process;
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
     pub struct ComplexPrefixAs(pub Vec<u32>);
 
     // impl MergeUpdate for ComplexPrefixAs {
@@ -38,6 +41,21 @@ mod full_table {
     //         new_meta.push(self.0[0]);
     //         Ok((ComplexPrefixAs(new_meta), ()))
     //     }
+    // }
+
+    impl Meta for ComplexPrefixAs {
+        type Orderable<'a> = Asn;
+        type TBI = ();
+
+        fn as_orderable(&self, _tbi: Self::TBI) -> Asn { 
+            self.0[0].into()
+        }
+    }
+
+    // impl Orderable<u32, Rfc4271> for ComplexPrefixAs {
+    //     fn get_id(&self) -> &Self {
+    //         &self.0
+    //     }   
     // }
 
     impl std::fmt::Display for ComplexPrefixAs {

--- a/src/local_vec/tests/full_table_single.rs
+++ b/src/local_vec/tests/full_table_single.rs
@@ -110,9 +110,10 @@ mod full_table {
                 let query = tree_bitmap.match_prefix(&pfx.prefix,
                         &MatchOptions {
                         match_type: MatchType::LongestMatch,
-                        include_all_records: false,
+                        include_withdrawn: false,
                         include_less_specifics: false,
                         include_more_specifics: false,
+                        mui: None
                     },
                 );
 
@@ -147,9 +148,10 @@ mod full_table {
                             &pfx.unwrap(),
                             &MatchOptions {
                                 match_type: MatchType::LongestMatch,
-                                include_all_records: false,
+                                include_withdrawn: false,
                                 include_less_specifics: false,
                                 include_more_specifics: false,
+                                mui: None
                             },
                         );
                         if let Some(_pfx) = res.prefix {

--- a/src/local_vec/tests/more_specifics_single.rs
+++ b/src/local_vec/tests/more_specifics_single.rs
@@ -32,7 +32,7 @@ mod tests {
         ];
 
         for pfx in pfxs.iter() {
-            tree_bitmap.insert(pfx, PrefixAs(666), None)?;
+            tree_bitmap.insert(pfx, PrefixAs(666))?;
         }
         println!("------ end of inserts\n");
 
@@ -102,7 +102,7 @@ mod tests {
         ];
 
         for pfx in pfxs.iter() {
-            tree_bitmap.insert(&pfx.unwrap(), PrefixAs(666), None)?;
+            tree_bitmap.insert(&pfx.unwrap(), PrefixAs(666))?;
         }
         println!("------ end of inserts\n");
         

--- a/src/local_vec/tests/more_specifics_single.rs
+++ b/src/local_vec/tests/more_specifics_single.rs
@@ -54,9 +54,10 @@ mod tests {
                 &spfx.0.unwrap(),
                 &MatchOptions {
                     match_type: MatchType::ExactMatch,
-                    include_all_records: false,
+                    include_withdrawn: false,
                     include_less_specifics: false,
                     include_more_specifics: true,
+                    mui: None
                 },
             );
             println!("em/m-s: {:#?}", found_result);
@@ -129,9 +130,10 @@ mod tests {
                 &spfx.0.unwrap(),
                 &MatchOptions {
                     match_type: MatchType::LongestMatch,
-                    include_all_records: false,
+                    include_withdrawn: false,
                     include_less_specifics: false,
                     include_more_specifics: true,
+                    mui: None
                 },
             );
             println!("em/m-s: {}", found_result);

--- a/src/local_vec/tree.rs
+++ b/src/local_vec/tree.rs
@@ -66,7 +66,7 @@ impl<'a, AF: 'static + AddressFamily, NodeId: SortableNodeId + Copy>
     }
 }
 
-pub(crate) struct PrefixCacheGuard<
+pub struct PrefixCacheGuard<
     'a,
     AF: 'static + AddressFamily,
     Meta: crate::prefix_record::Meta,
@@ -431,7 +431,7 @@ where
 
     // This function assembles the prefixes of a child node starting on a specified bit position in a ptr_vec of
     // `current_node` into a vec, then adds all prefixes of these children recursively into a vec and returns that.
-    pub fn get_all_more_specifics_from_nibble<S: Stride>(
+    pub fn get_all_more_specifics_from_nibble<S>(
         &self,
         current_node: &TreeBitMapNode<Store::AF, S, Store::NodeType>,
         nibble: u32,

--- a/src/local_vec/tree.rs
+++ b/src/local_vec/tree.rs
@@ -3,9 +3,7 @@ use std::{
     marker::PhantomData,
 };
 
-use crate::prefix_record::MergeUpdate;
-
-use crate::af::{AddressFamily, Zero};
+use crate::{af::{AddressFamily, Zero}, custom_alloc::UpsertReport};
 use crate::local_vec::node::TreeBitMapNode;
 use crate::local_vec::storage_backend::StorageBackend;
 use crate::match_node_for_strides_with_local_vec;
@@ -243,7 +241,7 @@ where
     pub(crate) fn insert(
         &mut self,
         pfx: InternalPrefixRecord<Store::AF, Store::Meta>,
-        user_data: Option<&<Store::Meta as MergeUpdate>::UserDataIn>,
+        // user_data: Option<&<Store::Meta>::UserDataIn>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut stride_end: u8 = 0;
         let mut cur_i = self.store.get_root_node_id();
@@ -268,7 +266,7 @@ where
             let next_node_idx = match_node_for_strides_with_local_vec![
                 // applicable to the whole outer match in the marco
                 self;
-                user_data;
+                // user_data;
                 nibble_len;
                 nibble;
                 is_last_stride;
@@ -337,11 +335,13 @@ where
         &mut self,
         update_node_idx: <<Store as StorageBackend>::NodeType as SortableNodeId>::Part,
         meta: Store::Meta,
-        user_data: Option<&<Store::Meta as MergeUpdate>::UserDataIn>,
-    ) -> Result<<Store::Meta as MergeUpdate>::UserDataOut, Box<dyn std::error::Error>> {
+        // user_data: Option<&<Store::Meta>::UserDataIn>,
+    ) -> Result<UpsertReport, Box<dyn std::error::Error>> {
         match self.store.retrieve_prefix_mut(update_node_idx) {
             Some(update_pfx) => {
-                <Store::Meta>::merge_update(&mut update_pfx.meta, meta, user_data)
+                update_pfx.meta = meta;
+                Ok(UpsertReport { cas_count: 0, prefix_new: false, mui_new: false, mui_count: 0 })
+                // <Store::Meta>::merge_update(&mut update_pfx.meta, meta)
             }
             // TODO
             // Use/create proper error types

--- a/src/meta_examples.rs
+++ b/src/meta_examples.rs
@@ -1,5 +1,10 @@
 //------------ PrefixAs Metadata impl ---------------------------------------
 
+use inetnum::asn::Asn;
+use routecore::bgp::path_selection::{Rfc4271, TiebreakerInfo};
+
+use crate::Meta;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PrefixAs(pub u32);
 
@@ -27,6 +32,14 @@ pub struct PrefixAs(pub u32);
 //         Ok((PrefixAs(update_meta.0), ()))
 //     }
 // }
+
+impl Meta for PrefixAs {
+    type Orderable<'a> = Asn;
+    type TBI = ();
+    fn as_orderable(&self, _tbi: Self::TBI) -> Asn {
+        self.0.into()
+    }
+}
 
 impl std::fmt::Display for PrefixAs {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -63,6 +76,13 @@ impl std::fmt::Display for NoMeta {
         f.write_str("NoMeta")
     }
 }
+
+impl Meta for NoMeta {
+    type Orderable<'a> = ();
+    type TBI = ();
+    fn as_orderable(&self, _tbi: Self::TBI) {}
+}
+
 
 // impl MergeUpdate for NoMeta {
 //     type UserDataIn = ();

--- a/src/meta_examples.rs
+++ b/src/meta_examples.rs
@@ -60,7 +60,7 @@ impl std::fmt::Debug for NoMeta {
 
 impl std::fmt::Display for NoMeta {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("")
+        f.write_str("NoMeta")
     }
 }
 

--- a/src/meta_examples.rs
+++ b/src/meta_examples.rs
@@ -1,34 +1,32 @@
 //------------ PrefixAs Metadata impl ---------------------------------------
 
-use crate::prefix_record::MergeUpdate;
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PrefixAs(pub u32);
 
-impl MergeUpdate for PrefixAs {
-    type UserDataIn = ();
-    type UserDataOut = ();
+// impl MergeUpdate for PrefixAs {
+//     type UserDataIn = ();
+//     type UserDataOut = ();
 
-    fn merge_update(
-        &mut self,
-        update_record: PrefixAs,
-        _: Option<&Self::UserDataIn>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        self.0 = update_record.0;
-        Ok(())
-    }
+//     fn merge_update(
+//         &mut self,
+//         update_record: PrefixAs,
+//         _: Option<&Self::UserDataIn>,
+//     ) -> Result<(), Box<dyn std::error::Error>> {
+//         self.0 = update_record.0;
+//         Ok(())
+//     }
 
-    fn clone_merge_update(
-        &self,
-        update_meta: &Self,
-        _: Option<&Self::UserDataIn>,
-    ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
-    where
-        Self: std::marker::Sized,
-    {
-        Ok((PrefixAs(update_meta.0), ()))
-    }
-}
+//     fn clone_merge_update(
+//         &self,
+//         update_meta: &Self,
+//         _: Option<&Self::UserDataIn>,
+//     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
+//     where
+//         Self: std::marker::Sized,
+//     {
+//         Ok((PrefixAs(update_meta.0), ()))
+//     }
+// }
 
 impl std::fmt::Display for PrefixAs {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -66,23 +64,23 @@ impl std::fmt::Display for NoMeta {
     }
 }
 
-impl MergeUpdate for NoMeta {
-    type UserDataIn = ();
-    type UserDataOut = ();
+// impl MergeUpdate for NoMeta {
+//     type UserDataIn = ();
+//     type UserDataOut = ();
 
-    fn merge_update(
-        &mut self,
-        _: NoMeta,
-        _: Option<&Self::UserDataIn>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        Ok(())
-    }
+//     fn merge_update(
+//         &mut self,
+//         _: NoMeta,
+//         _: Option<&Self::UserDataIn>,
+//     ) -> Result<(), Box<dyn std::error::Error>> {
+//         Ok(())
+//     }
 
-    fn clone_merge_update(
-        &self,
-        _: &NoMeta,
-        _: Option<&Self::UserDataIn>,
-    ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>> {
-        Ok((NoMeta::Empty, ()))
-    }
-}
+//     fn clone_merge_update(
+//         &self,
+//         _: &NoMeta,
+//         _: Option<&Self::UserDataIn>,
+//     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>> {
+//         Ok((NoMeta::Empty, ()))
+//     }
+// }

--- a/src/prefix_record.rs
+++ b/src/prefix_record.rs
@@ -244,7 +244,7 @@ impl<M> PublicRecord<M> {
 
 impl<M: std::fmt::Display> std::fmt::Display for PublicRecord<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {{ ltime: {}, status: {}, meta: {} }}",
+        write!(f, "{{ mui: {}, ltime: {}, status: {}, meta: {} }}",
             self.multi_uniq_id,
             self.ltime,
             self.status,
@@ -538,11 +538,11 @@ impl<M: Meta> fmt::Display for RecordSet<M> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let arr_str_v4 =
             self.v4.iter().fold("".to_string(), |pfx_arr, pfx| {
-                format!("{} {:#?}", pfx_arr, *pfx)
+                format!("{} {}", pfx_arr, *pfx)
             });
         let arr_str_v6 =
             self.v6.iter().fold("".to_string(), |pfx_arr, pfx| {
-                format!("{} {:#?}", pfx_arr, *pfx)
+                format!("{} {}", pfx_arr, *pfx)
             });
 
         write!(f, "V4: [{}], V6: [{}]", arr_str_v4, arr_str_v6)

--- a/src/prefix_record.rs
+++ b/src/prefix_record.rs
@@ -22,7 +22,7 @@ where
 
 impl<M, AF> InternalPrefixRecord<AF, M>
 where
-    M: Meta + MergeUpdate,
+    M: Meta,
     AF: AddressFamily,
 {
     pub fn new_with_meta(
@@ -727,8 +727,8 @@ pub trait MergeUpdate: Send + Sync {
 /// Trait for types that can be used as metadata of a record
 pub trait Meta
 where
-    Self: fmt::Debug + fmt::Display + Clone + Sized + MergeUpdate {}
+    Self: fmt::Debug + fmt::Display + Clone + Sized + Send + Sync {}
 
 impl<T> Meta for T
 where
-    T: fmt::Debug + fmt::Display + Clone + Sized + MergeUpdate {}
+    T: fmt::Debug + fmt::Display + Clone + Sized + Send + Sync {}

--- a/src/prefix_record.rs
+++ b/src/prefix_record.rs
@@ -242,32 +242,17 @@ impl<M> PublicRecord<M> {
     }
 }
 
-impl<AF, M> From<(PrefixId<AF>, u32, MultiMapValue<M>)> for PublicRecord<M>
-where
-    AF: AddressFamily,
-    M: Meta,
-{
-    fn from(value: (PrefixId<AF>, u32, MultiMapValue<M>)) -> Self {
-        Self {
-            multi_uniq_id: value.1,
-            meta: value.2.meta,
-            ltime: value.2.ltime,
-            status: value.2.status,
-        }
-    }
-}
-
 impl<M: Debug> std::fmt::Display for PublicRecord<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} :{:?}", self.multi_uniq_id, self.meta)
     }
 }
 
-impl<M: Clone> From<(&u32, &MultiMapValue<M>)> for PublicRecord<M> {
-    fn from(value: (&u32, &MultiMapValue<M>)) -> Self {
+impl<M: Clone> From<(u32, MultiMapValue<M>)> for PublicRecord<M> {
+    fn from(value: (u32, MultiMapValue<M>)) -> Self {
         Self {
-            multi_uniq_id: *value.0,
-            meta: value.1.meta.clone(),
+            multi_uniq_id: value.0,
+            meta: value.1.meta,
             ltime: value.1.ltime,
             status: value.1.status,
         }

--- a/src/prefix_record.rs
+++ b/src/prefix_record.rs
@@ -51,7 +51,7 @@ where
 
 impl<M, AF> std::fmt::Display for InternalPrefixRecord<AF, M>
 where
-    M: Meta + MergeUpdate,
+    M: Meta,
     AF: AddressFamily,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -689,40 +689,40 @@ impl<'a, M: Meta> Iterator for RecordSetIter<'a, M> {
 /// wants to be able to be stored. It should describe how the metadata for an
 /// existing record should be merged with newly arriving records for the same
 /// key.
-pub trait MergeUpdate: Send + Sync {
-    /// User-defined data to be passed in to the merge implementation.
-    type UserDataIn: Debug + Sync + Send;
+// pub trait MergeUpdate: Send + Sync {
+//     /// User-defined data to be passed in to the merge implementation.
+//     type UserDataIn: Debug + Sync + Send;
 
-    /// User-defined data returned by the users implementation of the merge
-    /// operations. Set to () if not needed.
-    /// TODO: Define () as the default when the 'associated_type_defaults'
-    /// Rust feature is stabilized. See:
-    ///   https://github.com/rust-lang/rust/issues/29661
-    type UserDataOut;
+//     /// User-defined data returned by the users implementation of the merge
+//     /// operations. Set to () if not needed.
+//     /// TODO: Define () as the default when the 'associated_type_defaults'
+//     /// Rust feature is stabilized. See:
+//     ///   https://github.com/rust-lang/rust/issues/29661
+//     type UserDataOut;
 
-    fn merge_update(
-        &mut self,
-        update_meta: Self,
-        user_data: Option<&Self::UserDataIn>,
-    ) -> Result<Self::UserDataOut, Box<dyn std::error::Error>>;
+//     fn merge_update(
+//         &mut self,
+//         update_meta: Self,
+//         user_data: Option<&Self::UserDataIn>,
+//     ) -> Result<Self::UserDataOut, Box<dyn std::error::Error>>;
 
-    // This is part of the Read-Copy-Update pattern for updating a record
-    // concurrently. The Read part should be done by the caller and then
-    // the result should be passed in into this function together with
-    // the new meta-data that updates it. This function will then create
-    // a copy (in the pattern lingo, but in Rust that would be a Clone,
-    // since we're not requiring Copy for Meta) and update that with a
-    // copy of the new meta-data. It then returns the result of that merge.
-    // The caller should then proceed to insert that as a new entry
-    // in the global store.
-    fn clone_merge_update(
-        &self,
-        update_meta: &Self,
-        user_data: Option<&Self::UserDataIn>,
-    ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
-    where
-        Self: std::marker::Sized;
-}
+//     // This is part of the Read-Copy-Update pattern for updating a record
+//     // concurrently. The Read part should be done by the caller and then
+//     // the result should be passed in into this function together with
+//     // the new meta-data that updates it. This function will then create
+//     // a copy (in the pattern lingo, but in Rust that would be a Clone,
+//     // since we're not requiring Copy for Meta) and update that with a
+//     // copy of the new meta-data. It then returns the result of that merge.
+//     // The caller should then proceed to insert that as a new entry
+//     // in the global store.
+//     fn clone_merge_update(
+//         &self,
+//         update_meta: &Self,
+//         user_data: Option<&Self::UserDataIn>,
+//     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
+//     where
+//         Self: std::marker::Sized;
+// }
 
 /// Trait for types that can be used as metadata of a record
 pub trait Meta

--- a/src/prefix_record.rs
+++ b/src/prefix_record.rs
@@ -5,6 +5,7 @@ use std::{cmp::Ordering, sync::Arc};
 use crate::local_array::store::atomic_types::{MultiMapValue, RouteStatus};
 use crate::{af::AddressFamily, local_array::node::PrefixId};
 use inetnum::addr::Prefix;
+use routecore::bgp::path_selection::{OrdRoute, Rfc4271, TiebreakerInfo};
 
 //------------ InternalPrefixRecord -----------------------------------------
 
@@ -740,8 +741,18 @@ impl<'a, M: Meta> Iterator for RecordSetIter<'a, M> {
 /// Trait for types that can be used as metadata of a record
 pub trait Meta
 where
-    Self: fmt::Debug + fmt::Display + Clone + Sized + Send + Sync {}
+    Self: fmt::Debug + fmt::Display + Clone + Sized + Send + Sync {
+        type Orderable<'a>: Ord where Self: 'a;
+        type TBI: Copy;
 
-impl<T> Meta for T
-where
-    T: fmt::Debug + fmt::Display + Clone + Sized + Send + Sync {}
+        fn as_orderable(&self, tbi: Self::TBI) -> Self::Orderable<'_>;
+    }
+
+impl Meta for inetnum::asn::Asn {
+    type Orderable<'a> = inetnum::asn::Asn;
+    type TBI = ();
+
+    fn as_orderable(&self, _tbi: Self::TBI) -> inetnum::asn::Asn {
+        *self
+    }
+}

--- a/src/prefix_record.rs
+++ b/src/prefix_record.rs
@@ -608,10 +608,10 @@ impl<'a, M: Meta + 'a>
             let u_pfx = pfx.prefix;
             match u_pfx.addr() {
                 std::net::IpAddr::V4(_) => {
-                    v4.push(PublicPrefixRecord::new(u_pfx, pfx.meta.clone().into()));
+                    v4.push(PublicPrefixRecord::new(u_pfx, pfx.meta.clone()));
                 }
                 std::net::IpAddr::V6(_) => {
-                    v6.push(PublicPrefixRecord::new(u_pfx, pfx.meta.clone().into()));
+                    v6.push(PublicPrefixRecord::new(u_pfx, pfx.meta.clone()));
                 }
             }
         }

--- a/src/prefix_record.rs
+++ b/src/prefix_record.rs
@@ -242,9 +242,14 @@ impl<M> PublicRecord<M> {
     }
 }
 
-impl<M: Debug> std::fmt::Display for PublicRecord<M> {
+impl<M: std::fmt::Display> std::fmt::Display for PublicRecord<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} :{:?}", self.multi_uniq_id, self.meta)
+        write!(f, "{}: {{ ltime: {}, status: {}, meta: {} }}",
+            self.multi_uniq_id,
+            self.ltime,
+            self.status,
+            self.meta
+        )
     }
 }
 
@@ -272,6 +277,10 @@ impl<M: Meta> PublicPrefixRecord<M> {
     pub fn new(prefix: Prefix, meta: Vec<PublicRecord<M>>) -> Self {
         Self { prefix, meta }
     }
+
+    pub fn get_record_for_mui(&self, mui: u32) -> Option<&PublicRecord<M>> {
+        self.meta.iter().find(|r| r.multi_uniq_id == mui)
+    }
 }
 
 impl<AF, M> From<(PrefixId<AF>, Vec<PublicRecord<M>>)> for PublicPrefixRecord<M>
@@ -287,9 +296,13 @@ where
     }
 }
 
-impl<M: Meta> std::fmt::Display for PublicPrefixRecord<M> {
+impl<M: Meta + std::fmt::Display> std::fmt::Display for PublicPrefixRecord<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} :{:?}", self.prefix, self.meta)
+        write!(f, "{}: [", self.prefix)?;
+        for rec in &self.meta {
+            write!(f, "{},", rec)?;
+        }
+        write!(f, "]")
     }
 }
 

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -29,5 +29,6 @@ pub mod multi {
 
     pub use crate::custom_alloc::{Upsert, Counters, StoreStats, UpsertReport};
     pub use crate::custom_alloc::CustomAllocStorage;
-    pub use crate::custom_alloc::TieBreakerInfo;
+
+    pub use routecore::bgp::path_selection::TiebreakerInfo;
 }

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -5,8 +5,7 @@ pub use crate::{AddressFamily, IPv4, IPv6};
 
 pub use crate::prefix_record::{
     PublicPrefixRecord as PrefixRecord,
-    Meta,
-    MergeUpdate
+    Meta
 };
 pub use crate::{MatchOptions, MatchType, QueryResult};
 pub use crate::stride::{Stride3, Stride4, Stride5};

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -29,4 +29,5 @@ pub mod multi {
 
     pub use crate::custom_alloc::{Upsert, Counters, StoreStats, UpsertReport};
     pub use crate::custom_alloc::CustomAllocStorage;
+    pub use crate::custom_alloc::TieBreakerInfo;
 }

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -11,6 +11,7 @@ pub use crate::{MatchOptions, MatchType, QueryResult};
 pub use crate::stride::{Stride3, Stride4, Stride5};
 
 pub mod multi {
+    pub use std::sync::atomic::Ordering;
     pub use crate::MultiThreadedStore;
 
     pub use rotonda_macros::create_store;

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -24,7 +24,9 @@ pub mod multi {
     };
     pub use crate::local_array::tree::{PrefixId, StrideNodeId, TreeBitMap};
     pub use crate::local_array::store::errors::PrefixStoreError;
+    pub use crate::prefix_record::PublicRecord as Record;
+    pub use crate::local_array::store::atomic_types::RouteStatus;
 
-    pub use crate::custom_alloc::{Upsert, Counters, StoreStats};
+    pub use crate::custom_alloc::{Upsert, Counters, StoreStats, UpsertReport};
     pub use crate::custom_alloc::CustomAllocStorage;
 }

--- a/src/rotonda_store.rs
+++ b/src/rotonda_store.rs
@@ -85,7 +85,7 @@ pub struct MatchOptions {
     pub mui: Option<u32>
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum MatchType {
     ExactMatch,
     LongestMatch,
@@ -181,22 +181,22 @@ impl<M: Meta> fmt::Display for QueryResult<M> {
         //     Some(pfx_meta) => format!("{}", pfx_meta),
         //     None => "".to_string(),
         // };
-        write!(
-            f,
-            "match_type: {}\nprefix: {}\nmetadata: {}\nless_specifics: {}\nmore_specifics: {}",
-            self.match_type,
-            pfx_str,
-            format_args!("{:?}", self.prefix_meta),
-            if let Some(ls) = self.less_specifics.as_ref() {
-                format!("{}", ls)
-            } else {
-                "".to_string()
-            },
-            if let Some(ms) = self.more_specifics.as_ref() {
-                format!("{}", ms)
-            } else {
-                "".to_string()
-            },
-        )
+        writeln!(f, "match_type: {}", self.match_type)?;
+        writeln!(f, "prefix: {}", pfx_str)?;
+        write!(f, "meta: [ ")?;
+        for rec in &self.prefix_meta {
+            write!(f, "{},", rec)?;
+        }
+        writeln!(f, " ]")?;
+        writeln!(f, "less_specifics: {{ {} }}", if let Some(ls) = self.less_specifics.as_ref() {
+            format!("{}", ls)
+        } else {
+            "".to_string()
+        })?;
+        writeln!(f, "more_specifics: {{ {} }}", if let Some(ms) = self.more_specifics.as_ref() {
+            format!("{}", ms)
+        } else {
+            "".to_string()
+        })
     }
 }

--- a/src/rotonda_store.rs
+++ b/src/rotonda_store.rs
@@ -63,7 +63,7 @@ impl<'a> std::fmt::Debug for Strides<'a> {
 
 /// Options for the `match_prefix` method
 /// 
-/// The `MatchOptions` struct is used to specify the options for the 
+/// The `MatchOptions` struct is used to specify the options for the
 /// `match_prefix` method on the store.
 /// 
 /// Note that the `match_type` field may be different from the actual
@@ -75,11 +75,14 @@ pub struct MatchOptions {
     /// The requested [MatchType]
     pub match_type: MatchType,
     /// Unused
-    pub include_all_records: bool,
+    pub include_withdrawn: bool,
     /// Whether to include all less-specific records in the query result
     pub include_less_specifics: bool,
     // Whether to include all more-specific records in the query result
     pub include_more_specifics: bool,
+    /// Whether to return records for a specific multi_uniq_id, None indicates
+    /// all records.
+    pub mui: Option<u32>
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/tests/best-path.rs
+++ b/tests/best-path.rs
@@ -1,0 +1,123 @@
+use inetnum::addr::Prefix;
+use inetnum::asn::Asn;
+use rotonda_store::prelude::multi::PrefixStoreError;
+use rotonda_store::prelude::multi::Record;
+use rotonda_store::prelude::multi::RouteStatus;
+use rotonda_store::MatchOptions;
+use routecore::bgp::aspath::AsPath;
+use routecore::bgp::aspath::HopPath;
+use routecore::bgp::path_attributes::BgpIdentifier;
+use routecore::bgp::path_attributes::PaMap;
+use routecore::bgp::path_selection::DegreeOfPreference;
+use routecore::bgp::path_selection::RouteSource;
+use routecore::bgp::types::LocalPref;
+use routecore::bgp::types::Origin;
+use std::{str::FromStr, sync::atomic::Ordering};
+use rotonda_store::Meta;
+use rotonda_store::MultiThreadedStore;
+use routecore::bgp::{nlri::afisafi::Ipv4UnicastNlri, path_selection::{OrdRoute, Rfc4271, TiebreakerInfo}};
+
+#[derive(Clone, Debug)]
+pub struct Ipv4Route(u32, PaMap);
+
+impl std::fmt::Display for Ipv4Route {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl Meta for Ipv4Route {
+    type Orderable<'a> = OrdRoute<'a, Rfc4271>;
+    type TBI = TiebreakerInfo;
+
+    fn as_orderable(&self, tbi: Self::TBI) -> Self::Orderable<'_> {
+        routecore::bgp::path_selection::OrdRoute::rfc4271(&self.1, tbi).unwrap()
+    }
+}
+
+mod common {
+    use std::io::Write;
+
+    pub fn init() {
+        let _ = env_logger::builder()
+            .format(|buf, record| writeln!(buf, "{}", record.args()))
+            .is_test(true)
+            .try_init();
+    }
+}
+
+#[test]
+fn test_best_path_1() -> Result<(), Box<dyn std::error::Error>> {
+    crate::common::init();
+    
+    let tree_bitmap = std::sync::Arc::new(std::sync::Arc::new(MultiThreadedStore::<Ipv4Route>::new()?));
+
+    let pfx = Prefix::from_str("185.34.0.0/16")?;
+    let mut asns = [Asn::from(65400), Asn::from(65401), Asn::from(65402), Asn::from(65403), Asn::from(65404)].into_iter();
+    let mut pa_map = PaMap::empty();
+
+    pa_map.set::<LocalPref>(routecore::bgp::types::LocalPref(50));
+    pa_map.set::<HopPath>(
+        HopPath::from(vec![Asn::from(65400), Asn::from(65401), Asn::from(65402)])
+    );
+    pa_map.set::<Origin>(routecore::bgp::types::Origin(routecore::bgp::types::OriginType::Egp));
+
+    let mut asns_insert = vec![];
+
+    for (mui, _peer_addr) in [
+        (1, std::net::Ipv4Addr::from_str("192.168.12.1")?),
+        (2, std::net::Ipv4Addr::from_str("192.168.12.2")?),
+        (3, std::net::Ipv4Addr::from_str("192.168.12.3")?),
+        (4, std::net::Ipv4Addr::from_str("192.168.12.4")?),
+        (5, std::net::Ipv4Addr::from_str("192.168.12.5")?)
+    ] {
+        asns_insert.push(asns.next().unwrap());
+        let rec = Record::new(mui,0, RouteStatus::Active, Ipv4Route(mui, pa_map.clone()));
+        pa_map.set::<HopPath>(HopPath::from(asns_insert.clone()));
+        tree_bitmap.insert(
+            &pfx, 
+            rec,
+            None
+        )?;
+    }
+
+    let res = tree_bitmap.match_prefix(
+        &pfx,
+        &MatchOptions { 
+            match_type: rotonda_store::MatchType::ExactMatch, 
+            include_withdrawn: false,
+            include_less_specifics: false,
+            include_more_specifics: false,
+            mui: None
+        },
+        &rotonda_store::epoch::pin()
+    );
+
+    println!("{:?}", res.prefix_meta);
+    let best_path = tree_bitmap.best_path(&pfx, &rotonda_store::epoch::pin());
+    println!("ps outdated? {}", tree_bitmap.is_ps_outdated(&pfx, &rotonda_store::epoch::pin()).unwrap());
+    println!("{:?}", best_path);
+
+    // We didn't calculate the best path yet, but the prefix (and its entries)
+    // exists, so this should be `Some(Err(BestPathNotFound))` at this point.
+    assert_eq!(best_path.unwrap().err().unwrap(), PrefixStoreError::BestPathNotFound);
+
+    tree_bitmap.calculate_and_store_best_and_backup_path(
+        &pfx,
+        &TiebreakerInfo { 
+            source: RouteSource::Ebgp,
+            degree_of_preference: None,
+            local_asn: 65400.into(),
+            bgp_identifier: BgpIdentifier::from([0; 4]),
+            peer_addr: std::net::IpAddr::V4(std::net::Ipv4Addr::from_str("192.168.12.1")?)
+        },
+        &rotonda_store::epoch::pin()
+    )?;
+
+    let best_path = tree_bitmap.best_path(&pfx, &rotonda_store::epoch::pin());
+    println!("ps outdated? {}", tree_bitmap.is_ps_outdated(&pfx, &rotonda_store::epoch::pin()).unwrap());
+    println!("{:?}", best_path);
+    assert_eq!(best_path.unwrap().unwrap().multi_uniq_id, 1);
+
+    Ok(())
+}

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -1,7 +1,7 @@
 use std::{str::FromStr, sync::atomic::Ordering};
 
 use inetnum::{addr::Prefix, asn::Asn};
-use rotonda_store::{prelude::multi::{Record, RouteStatus}, MultiThreadedStore};
+use rotonda_store::{prelude::multi::{Record, RouteStatus}, MatchOptions, MultiThreadedStore};
 
 mod common {
     use std::io::Write;
@@ -18,6 +18,27 @@ mod common {
 fn test_concurrent_updates_1() -> Result<(), Box<dyn std::error::Error>> {
     crate::common::init();
 
+    let pfx_vec_1 = vec![
+        Prefix::from_str("185.34.0.0/16")?,
+        Prefix::from_str("185.34.10.0/24")?,
+        Prefix::from_str("185.34.11.0/24")?,
+        Prefix::from_str("183.0.0.0/8")?
+    ];
+
+    let pfx_vec_2 = vec![
+        Prefix::from_str("185.34.0.0/16")?,
+        Prefix::from_str("185.34.10.0/24")?,
+        Prefix::from_str("185.34.12.0/24")?,
+        Prefix::from_str("186.0.0.0/8")?
+    ];
+
+    let pfx_vec_3 = vec![
+        Prefix::from_str("185.36.0.0/16")?,
+        Prefix::from_str("185.34.10.0/24")?,
+        Prefix::from_str("185.34.12.0/24")?,
+        Prefix::from_str("187.0.0.0/8")?
+    ];
+
     struct MuiData {
         mui: u32,
         asn: Asn,
@@ -29,34 +50,19 @@ fn test_concurrent_updates_1() -> Result<(), Box<dyn std::error::Error>> {
     let mui_data_1 = MuiData {
         mui: 1,
         asn: 65501.into(),
-        pfxs: vec![
-            Prefix::from_str("185.34.0.0/16")?,
-            Prefix::from_str("185.34.10.0/24")?,
-            Prefix::from_str("185.34.11.0/24")?,
-            Prefix::from_str("183.0.0.0/8")?
-        ]
+        pfxs: pfx_vec_1.clone()
     };
 
     let mui_data_2 = MuiData {
         mui: 2,
         asn: 65502.into(),
-        pfxs: vec![
-            Prefix::from_str("185.34.0.0/16")?,
-            Prefix::from_str("185.34.10.0/24")?,
-            Prefix::from_str("185.34.12.0/24")?,
-            Prefix::from_str("186.0.0.0/8")?
-        ]
+        pfxs: pfx_vec_2.clone()
     };
 
     let mui_data_3 = MuiData {
         mui: 3,
         asn: 65503.into(),
-        pfxs: vec![
-            Prefix::from_str("185.36.0.0/16")?,
-            Prefix::from_str("185.34.10.0/24")?,
-            Prefix::from_str("185.34.12.0/24")?,
-            Prefix::from_str("187.0.0.0/8")?
-        ]
+        pfxs: pfx_vec_3.clone()
     };
 
     let cur_ltime = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
@@ -143,5 +149,208 @@ fn test_concurrent_updates_1() -> Result<(), Box<dyn std::error::Error>> {
     assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 2 && m.meta == 65502.into())));
     assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 1 || m.meta == 65501.into())));
 
+    
+    // Create Withdrawals
+    
+    let _: Vec<_> = pfx_vec_2.clone().into_iter()
+    .map(|pfx: Prefix| {
+        let tree_bitmap = tree_bitmap.clone();
+        let cur_ltime = cur_ltime.clone();
+
+        std::thread::Builder::new()
+            .name("2".to_string())
+            .spawn(move || {
+                print!("\nstart withdraw {} ---", 2);
+
+                let _ = cur_ltime.fetch_add(1, Ordering::Release);
+                tree_bitmap.mark_mui_as_withdrawn_for_prefix(&pfx, 2).unwrap();
+
+                println!("--thread withdraw 2 done.");
+            }).unwrap()
+    })
+    .map(|t| t.join())
+    .collect();
+
+    println!("{:#?}", tree_bitmap.prefixes_iter(&guard).collect::<Vec<_>>());
+
+    let match_options = MatchOptions {
+        match_type: rotonda_store::MatchType::ExactMatch,
+        include_withdrawn: true,
+        include_less_specifics: false,
+        include_more_specifics: false,
+        mui: None,
+    };
+
+    for pfx in pfx_vec_2 {
+        let guard = rotonda_store::epoch::pin();
+        let res = tree_bitmap.match_prefix(&pfx, &match_options, &guard);
+        assert_eq!(res.prefix, Some(pfx));
+        assert_eq!(res.prefix_meta.iter().find(|m| m.multi_uniq_id == 2).unwrap().status, RouteStatus::Withdrawn);
+    }
+    Ok(())
+}
+
+#[test]
+fn test_concurrent_updates_2() -> Result<(), Box<dyn std::error::Error>> {
+    crate::common::init();
+
+    let pfx_vec_1 = vec![
+        Prefix::from_str("185.33.0.0/16")?,
+        Prefix::from_str("185.33.0.0/16")?,
+        Prefix::from_str("185.33.0.0/16")?,
+        Prefix::from_str("185.33.0.0/16")?
+    ];
+
+    let pfx_vec_2 = vec![
+        Prefix::from_str("185.34.0.0/16")?,
+        Prefix::from_str("185.34.0.0/16")?,
+        Prefix::from_str("185.34.14.0/24")?,
+        Prefix::from_str("187.0.0.0/8")?
+    ];
+
+    let pfx_vec_3 = vec![
+        Prefix::from_str("185.35.0.0/16")?,
+        Prefix::from_str("185.34.15.0/24")?,
+        Prefix::from_str("185.34.15.0/24")?,
+        Prefix::from_str("188.0.0.0/8")?
+    ];
+
+    #[derive(Debug)]
+    struct MuiData {
+        mui: u32,
+        asn: u32,
+    }
+
+    let tree_bitmap = std::sync::Arc::new(MultiThreadedStore::<Asn>::new()?);
+
+    const MUI_DATA: [MuiData; 4] = [
+        MuiData {
+            mui: 1,
+            asn: 65501
+        },
+        MuiData {
+            mui: 2,
+            asn: 65502
+        },
+        MuiData {
+            mui: 3,
+            asn: 65503
+        },
+        MuiData {
+            mui: 4,
+            asn: 65504
+        }
+    ];
+
+    let cur_ltime = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+    let _: Vec<_> = vec![pfx_vec_1.clone(), pfx_vec_2.clone(), pfx_vec_3.clone()].into_iter().enumerate()
+        .map(|(n, pfxs)| {
+            let tree_bitmap = tree_bitmap.clone();
+            let cur_ltime = cur_ltime.clone();
+
+            std::thread::Builder::new()
+                .name(n.to_string())
+                .spawn(move || {
+                    print!("\nstart prefix batch {} ---", n);
+                    for (i, pfx) in pfxs.iter().enumerate() {
+                        let _ = cur_ltime.fetch_add(1, Ordering::Release);
+              
+                        match tree_bitmap.insert(
+                            pfx,
+                            Record::new(i as u32 + 1, cur_ltime.load(Ordering::Acquire), RouteStatus::Active, MUI_DATA[i].asn.into()),
+                            None
+                        ) {
+                            Ok(_) => {}
+                            Err(e) => {
+                                println!("{}", e);
+                            }
+                        };
+                    }
+
+                    println!("--thread prefix batch {} done.", n);
+                }).unwrap()
+        })
+        .map(|t| t.join())
+        .collect();
+
+    let guard = rotonda_store::epoch::pin();
+    println!("{:#?}", tree_bitmap.prefixes_iter(&guard).collect::<Vec<_>>());
+
+    let all_pfxs_iter = tree_bitmap.prefixes_iter(&guard).collect::<Vec<_>>();
+
+    let pfx = Prefix::from_str("185.33.0.0/16").unwrap();
+    assert!(all_pfxs_iter.iter().any(|p| p.prefix == pfx));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 1 && m.meta == 65501.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 2 && m.meta == 65502.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 3 && m.meta == 65503.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 4 && m.meta == 65504.into()));
+
+    let pfx = Prefix::from_str("185.34.0.0/16").unwrap();
+    assert_eq!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.len(), 2);
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 1 && m.meta == 65501.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 2 && m.meta == 65502.into()));
+
+    let pfx = Prefix::from_str("185.34.14.0/24").unwrap();
+    assert_eq!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.len(), 1);
+    assert_eq!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta[0].meta, Asn::from_u32(65503));
+
+    let pfx = Prefix::from_str("187.0.0.0/8").unwrap();
+    assert_eq!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.len(), 1);
+    assert_eq!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta[0].meta, Asn::from_u32(65504));
+
+    let pfx = Prefix::from_str("185.35.0.0/16").unwrap();
+    assert_eq!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.len(), 1);
+    assert_eq!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta[0].meta, Asn::from_u32(65501));
+
+    let pfx = Prefix::from_str("185.34.15.0/24").unwrap();
+    assert_eq!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.len(), 2);
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 2 && m.meta == 65502.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 3 && m.meta == 65503.into()));
+    
+    let pfx = Prefix::from_str("188.0.0.0/8").unwrap();
+    assert_eq!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.len(), 1);
+    assert_eq!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta[0].meta, Asn::from_u32(65504));
+
+    // Create Withdrawals
+    let wd_pfxs = [pfx_vec_1[1], pfx_vec_2[1], pfx_vec_3[1]];
+    
+    let _: Vec<_> = wd_pfxs.into_iter()
+    .map(|pfx: Prefix| {
+        let tree_bitmap = tree_bitmap.clone();
+        let cur_ltime = cur_ltime.clone();
+
+        std::thread::Builder::new()
+            .name("2".to_string())
+            .spawn(move || {
+                print!("\nstart withdraw {} ---", 2);
+
+                let _ = cur_ltime.fetch_add(1, Ordering::Release);
+                tree_bitmap.mark_mui_as_withdrawn_for_prefix(&pfx, 2).unwrap();
+
+                println!("--thread withdraw 2 done.");
+            }).unwrap()
+    })
+    .map(|t| t.join())
+    .collect();
+
+    println!("{:#?}", tree_bitmap.prefixes_iter(&guard).collect::<Vec<_>>());
+
+    let match_options = MatchOptions {
+        match_type: rotonda_store::MatchType::ExactMatch,
+        include_withdrawn: true,
+        include_less_specifics: false,
+        include_more_specifics: false,
+        mui: None,
+    };
+
+    for pfx in wd_pfxs {
+        let guard = rotonda_store::epoch::pin();
+        let res = tree_bitmap.match_prefix(&pfx, &match_options, &guard);
+        assert_eq!(res.prefix, Some(pfx));
+        assert_eq!(res.prefix_meta.iter().find(|m| m.multi_uniq_id == 2).unwrap().status, RouteStatus::Withdrawn);
+    }
+
+    // let all_active_pfxs = tree_bitmap.
     Ok(())
 }

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -1,0 +1,147 @@
+use std::{str::FromStr, sync::atomic::Ordering};
+
+use inetnum::{addr::Prefix, asn::Asn};
+use rotonda_store::{prelude::multi::{Record, RouteStatus}, MultiThreadedStore};
+
+mod common {
+    use std::io::Write;
+
+    pub fn init() {
+        let _ = env_logger::builder()
+            .format(|buf, record| writeln!(buf, "{}", record.args()))
+            .is_test(true)
+            .try_init();
+    }
+}
+
+#[test]
+fn test_concurrent_updates_1() -> Result<(), Box<dyn std::error::Error>> {
+    crate::common::init();
+
+    struct MuiData {
+        mui: u32,
+        asn: Asn,
+        pfxs: Vec<Prefix>
+    }
+
+    let tree_bitmap = std::sync::Arc::new(MultiThreadedStore::<Asn>::new()?);
+
+    let mui_data_1 = MuiData {
+        mui: 1,
+        asn: 65501.into(),
+        pfxs: vec![
+            Prefix::from_str("185.34.0.0/16")?,
+            Prefix::from_str("185.34.10.0/24")?,
+            Prefix::from_str("185.34.11.0/24")?,
+            Prefix::from_str("183.0.0.0/8")?
+        ]
+    };
+
+    let mui_data_2 = MuiData {
+        mui: 2,
+        asn: 65502.into(),
+        pfxs: vec![
+            Prefix::from_str("185.34.0.0/16")?,
+            Prefix::from_str("185.34.10.0/24")?,
+            Prefix::from_str("185.34.12.0/24")?,
+            Prefix::from_str("186.0.0.0/8")?
+        ]
+    };
+
+    let mui_data_3 = MuiData {
+        mui: 3,
+        asn: 65503.into(),
+        pfxs: vec![
+            Prefix::from_str("185.36.0.0/16")?,
+            Prefix::from_str("185.34.10.0/24")?,
+            Prefix::from_str("185.34.12.0/24")?,
+            Prefix::from_str("187.0.0.0/8")?
+        ]
+    };
+
+    let cur_ltime = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+    let _: Vec<_> = vec![mui_data_1, mui_data_2, mui_data_3].into_iter()
+        .map(|data: MuiData| {
+            let tree_bitmap = tree_bitmap.clone();
+            let cur_ltime = cur_ltime.clone();
+
+            std::thread::Builder::new()
+                .name(data.mui.to_string())
+                .spawn(move || {
+                    print!("\nstart {} ---", data.mui);
+                    for pfx in data.pfxs {
+                        let _ = cur_ltime.fetch_add(1, Ordering::Release);
+              
+                        match tree_bitmap.insert(
+                            &pfx,
+                            Record::new(data.mui, cur_ltime.load(Ordering::Acquire), RouteStatus::Active, data.asn),
+                            None
+                        ) {
+                            Ok(_) => {}
+                            Err(e) => {
+                                println!("{}", e);
+                            }
+                        };
+                    }
+
+                    println!("--thread {} done.", data.mui);
+                }).unwrap()
+        })
+        .map(|t| t.join())
+        .collect();
+
+    let guard = rotonda_store::epoch::pin();
+    println!("{:#?}", tree_bitmap.prefixes_iter(&guard).collect::<Vec<_>>());
+
+    let all_pfxs_iter = tree_bitmap.prefixes_iter(&guard).collect::<Vec<_>>();
+
+    let pfx = Prefix::from_str("185.34.0.0/16").unwrap();
+    assert!(all_pfxs_iter.iter().any(|p| p.prefix == pfx));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 1 && m.meta == 65501.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 2 && m.meta == 65502.into()));
+
+    let pfx = Prefix::from_str("185.34.10.0/24").unwrap();
+    assert!(all_pfxs_iter.iter().any(|p| p.prefix == pfx));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 1 && m.meta == 65501.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 2 && m.meta == 65502.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 3 && m.meta == 65503.into()));
+
+    let pfx = Prefix::from_str("185.34.11.0/24").unwrap();
+    assert!(all_pfxs_iter.iter().any(|p| p.prefix == pfx));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 1 && m.meta == 65501.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 2 || m.meta == 65502.into())));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 3 || m.meta == 65503.into())));
+
+    let pfx = Prefix::from_str("185.34.11.0/24").unwrap();
+    assert!(all_pfxs_iter.iter().any(|p| p.prefix == pfx));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 1 && m.meta == 65501.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 2 || m.meta == 65502.into())));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 3 && m.meta == 65503.into())));
+
+    let pfx = Prefix::from_str("185.34.12.0/24").unwrap();
+    assert!(all_pfxs_iter.iter().any(|p| p.prefix == pfx));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 2 && m.meta == 65502.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 3 && m.meta == 65503.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 1 || m.meta == 65501.into())));
+
+    let pfx = Prefix::from_str("183.0.0.0/8")?;
+    assert!(all_pfxs_iter.iter().any(|p| p.prefix == pfx));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 1 || m.meta == 65501.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 2 && m.meta == 65502.into())));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 3 && m.meta == 65503.into())));
+    
+    let pfx = Prefix::from_str("186.0.0.0/8")?;
+    assert!(all_pfxs_iter.iter().any(|p| p.prefix == pfx));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 2 && m.meta == 65502.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 1 || m.meta == 65501.into())));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 3 && m.meta == 65503.into())));
+    
+    let pfx = Prefix::from_str("187.0.0.0/8")?;
+    assert!(all_pfxs_iter.iter().any(|p| p.prefix == pfx));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().any(|m| m.multi_uniq_id == 3 && m.meta == 65503.into()));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 2 && m.meta == 65502.into())));
+    assert!(all_pfxs_iter.iter().find(|p| p.prefix == pfx).unwrap().meta.iter().all(|m| !(m.multi_uniq_id == 1 || m.meta == 65501.into())));
+
+    Ok(())
+}

--- a/tests/full-table.rs
+++ b/tests/full-table.rs
@@ -13,32 +13,32 @@ mod tests {
     #[derive(Debug, Clone)]
     pub struct ComplexPrefixAs(pub Vec<u32>);
 
-    impl MergeUpdate for ComplexPrefixAs {
-        type UserDataIn = String;
-        type UserDataOut = ();
+    // impl MergeUpdate for ComplexPrefixAs {
+    //     type UserDataIn = String;
+    //     type UserDataOut = ();
 
-        fn merge_update(
-            &mut self,
-            update_record: ComplexPrefixAs,
-            _: Option<&Self::UserDataIn>,
-        ) -> Result<(), Box<dyn std::error::Error>> {
-            self.0 = update_record.0;
-            Ok(())
-        }
+    //     fn merge_update(
+    //         &mut self,
+    //         update_record: ComplexPrefixAs,
+    //         _: Option<&Self::UserDataIn>,
+    //     ) -> Result<(), Box<dyn std::error::Error>> {
+    //         self.0 = update_record.0;
+    //         Ok(())
+    //     }
 
-        fn clone_merge_update(
-            &self,
-            update_meta: &Self,
-            _: Option<&Self::UserDataIn>,
-        ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
-        where
-            Self: std::marker::Sized,
-        {
-            let mut new_meta = update_meta.0.clone();
-            new_meta.push(self.0[0]);
-            Ok((ComplexPrefixAs(new_meta), ()))
-        }
-    }
+    //     fn clone_merge_update(
+    //         &self,
+    //         update_meta: &Self,
+    //         _: Option<&Self::UserDataIn>,
+    //     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
+    //     where
+    //         Self: std::marker::Sized,
+    //     {
+    //         let mut new_meta = update_meta.0.clone();
+    //         new_meta.push(self.0[0]);
+    //         Ok((ComplexPrefixAs(new_meta), ()))
+    //     }
+    // }
 
     impl std::fmt::Display for ComplexPrefixAs {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -95,8 +95,8 @@ mod tests {
         ];
         for _strides in strides_vec.iter().enumerate() {
             let mut pfxs: Vec<PrefixRecord<ComplexPrefixAs>> = vec![];
-            let tree_bitmap = MultiThreadedStore::<ComplexPrefixAs>::new()?
-                .with_user_data("Testing".to_string());
+            let tree_bitmap = MultiThreadedStore::<ComplexPrefixAs>::new()?;
+                // .with_user_data("Testing".to_string());
 
             if let Err(err) = load_prefixes(&mut pfxs) {
                 println!("error running example: {}", err);

--- a/tests/full-table.rs
+++ b/tests/full-table.rs
@@ -116,9 +116,10 @@ mod tests {
                 let query = tree_bitmap.match_prefix(&pfx.prefix,
                         &MatchOptions {
                         match_type: MatchType::LongestMatch,
-                        include_all_records: false,
+                        include_withdrawn: false,
                         include_less_specifics: false,
                         include_more_specifics: false,
+                        mui: None
                     },
                     guard
                 );
@@ -154,9 +155,10 @@ mod tests {
                             &pfx.unwrap(),
                             &MatchOptions {
                                 match_type: MatchType::LongestMatch,
-                                include_all_records: false,
+                                include_withdrawn: false,
                                 include_less_specifics: false,
                                 include_more_specifics: false,
+                                mui: None
                             },
                             guard,
                         );

--- a/tests/full-table.rs
+++ b/tests/full-table.rs
@@ -78,7 +78,7 @@ mod tests {
                     vec![Record::new(
                         0,
                         0,
-                        RouteStatus::InConvergence,
+                        RouteStatus::Active,
                         ComplexPrefixAs(vec![asn])
                     )],
                 );
@@ -105,7 +105,7 @@ mod tests {
 
             let inserts_num = pfxs.len();
             for pfx in pfxs.into_iter() {
-                match tree_bitmap.insert(&pfx.prefix, pfx.meta[0].clone()) {
+                match tree_bitmap.insert(&pfx.prefix, pfx.meta[0].clone(), None) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/tests/full-table.rs
+++ b/tests/full-table.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "csv")]
 #[cfg(test)]
 mod tests {
+    use inetnum::asn::Asn;
     use rotonda_store::{
         prelude::*, 
         prelude::multi::*,
@@ -10,39 +11,21 @@ mod tests {
     use std::fs::File;
     use std::process;
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
     pub struct ComplexPrefixAs(pub Vec<u32>);
-
-    // impl MergeUpdate for ComplexPrefixAs {
-    //     type UserDataIn = String;
-    //     type UserDataOut = ();
-
-    //     fn merge_update(
-    //         &mut self,
-    //         update_record: ComplexPrefixAs,
-    //         _: Option<&Self::UserDataIn>,
-    //     ) -> Result<(), Box<dyn std::error::Error>> {
-    //         self.0 = update_record.0;
-    //         Ok(())
-    //     }
-
-    //     fn clone_merge_update(
-    //         &self,
-    //         update_meta: &Self,
-    //         _: Option<&Self::UserDataIn>,
-    //     ) -> Result<(Self, Self::UserDataOut), Box<dyn std::error::Error>>
-    //     where
-    //         Self: std::marker::Sized,
-    //     {
-    //         let mut new_meta = update_meta.0.clone();
-    //         new_meta.push(self.0[0]);
-    //         Ok((ComplexPrefixAs(new_meta), ()))
-    //     }
-    // }
 
     impl std::fmt::Display for ComplexPrefixAs {
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
             write!(f, "AS{:?}", self.0)
+        }
+    }
+
+    impl Meta for ComplexPrefixAs {
+        type Orderable<'a> = Asn;
+        type TBI = ();
+
+        fn as_orderable(&self, _tbi: Self::TBI) -> Asn {
+            Asn::from(self.0[0])
         }
     }
 

--- a/tests/full-table.rs
+++ b/tests/full-table.rs
@@ -75,7 +75,12 @@ mod tests {
                 let asn: u32 = record[2].parse().unwrap();
                 let pfx = PrefixRecord::new(
                     Prefix::new(net.into(), len)?,
-                    ComplexPrefixAs(vec![asn]),
+                    vec![Record::new(
+                        0,
+                        0,
+                        RouteStatus::InConvergence,
+                        ComplexPrefixAs(vec![asn])
+                    )],
                 );
                 pfxs.push(pfx);
             }
@@ -100,7 +105,7 @@ mod tests {
 
             let inserts_num = pfxs.len();
             for pfx in pfxs.into_iter() {
-                match tree_bitmap.insert(&pfx.prefix, 0, pfx.meta) {
+                match tree_bitmap.insert(&pfx.prefix, pfx.meta[0].clone()) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/tests/full-table.rs
+++ b/tests/full-table.rs
@@ -100,7 +100,7 @@ mod tests {
 
             let inserts_num = pfxs.len();
             for pfx in pfxs.into_iter() {
-                match tree_bitmap.insert(&pfx.prefix, pfx.meta) {
+                match tree_bitmap.insert(&pfx.prefix, 0, pfx.meta) {
                     Ok(_) => {}
                     Err(e) => {
                         println!("{}", e);

--- a/tests/more-more-specifics.rs
+++ b/tests/more-more-specifics.rs
@@ -31,7 +31,7 @@ mod tests {
 
         for pfx in pfxs.iter() {
             tree_bitmap.insert(
-                pfx, Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(666))
+                pfx, Record::new(0, 0, RouteStatus::Active, PrefixAs(666)), None
             )?;
         }
         println!("------ end of inserts\n");
@@ -102,9 +102,9 @@ mod tests {
         ];
 
         let ltime = 0;
-        let status = RouteStatus::InConvergence;
+        let status = RouteStatus::Active;
         for pfx in pfxs.iter() {
-            tree_bitmap.insert(&pfx.unwrap(), Record::new(0, ltime, status, PrefixAs(666)))?;
+            tree_bitmap.insert(&pfx.unwrap(), Record::new(0, ltime, status, PrefixAs(666)), None)?;
         }
         println!("------ end of inserts\n");
         let guard = &epoch::pin();

--- a/tests/more-more-specifics.rs
+++ b/tests/more-more-specifics.rs
@@ -55,9 +55,10 @@ mod tests {
                 &spfx.0.unwrap(),
                 &MatchOptions {
                     match_type: MatchType::ExactMatch,
-                    include_all_records: false,
+                    include_withdrawn: false,
                     include_less_specifics: false,
                     include_more_specifics: true,
+                    mui: None,
                 },
                 guard
             );
@@ -132,9 +133,10 @@ mod tests {
                 &spfx.0.unwrap(),
                 &MatchOptions {
                     match_type: MatchType::LongestMatch,
-                    include_all_records: false,
+                    include_withdrawn: false,
                     include_less_specifics: false,
                     include_more_specifics: true,
+                    mui: None
                 },
                 guard
             );

--- a/tests/more-more-specifics.rs
+++ b/tests/more-more-specifics.rs
@@ -30,7 +30,7 @@ mod tests {
         ];
 
         for pfx in pfxs.iter() {
-            tree_bitmap.insert(pfx, PrefixAs(666))?;
+            tree_bitmap.insert(pfx, 0, PrefixAs(666))?;
         }
         println!("------ end of inserts\n");
 
@@ -100,7 +100,7 @@ mod tests {
         ];
 
         for pfx in pfxs.iter() {
-            tree_bitmap.insert(&pfx.unwrap(), PrefixAs(666))?;
+            tree_bitmap.insert(&pfx.unwrap(), 0, PrefixAs(666))?;
         }
         println!("------ end of inserts\n");
         let guard = &epoch::pin();

--- a/tests/more-more-specifics.rs
+++ b/tests/more-more-specifics.rs
@@ -3,7 +3,7 @@ mod tests {
     use rotonda_store::{ 
         meta_examples::PrefixAs,
         prelude::*,
-        prelude::multi::*
+        prelude::multi::*,
     };
 
     use std::error::Error;
@@ -30,7 +30,9 @@ mod tests {
         ];
 
         for pfx in pfxs.iter() {
-            tree_bitmap.insert(pfx, 0, PrefixAs(666))?;
+            tree_bitmap.insert(
+                pfx, Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(666))
+            )?;
         }
         println!("------ end of inserts\n");
 
@@ -99,8 +101,10 @@ mod tests {
             Prefix::new(std::net::Ipv4Addr::new(17, 0, 120, 0).into(), 24), // 13
         ];
 
+        let ltime = 0;
+        let status = RouteStatus::InConvergence;
         for pfx in pfxs.iter() {
-            tree_bitmap.insert(&pfx.unwrap(), 0, PrefixAs(666))?;
+            tree_bitmap.insert(&pfx.unwrap(), Record::new(0, ltime, status, PrefixAs(666)))?;
         }
         println!("------ end of inserts\n");
         let guard = &epoch::pin();

--- a/tests/more-specifics.rs
+++ b/tests/more-specifics.rs
@@ -185,9 +185,10 @@ mod tests {
                 &spfx.0.unwrap(),
                 &MatchOptions {
                     match_type: MatchType::ExactMatch,
-                    include_all_records: false,
+                    include_withdrawn: false,
                     include_less_specifics: false,
                     include_more_specifics: true,
+                    mui: None
                 },
                 guard
             );

--- a/tests/more-specifics.rs
+++ b/tests/more-specifics.rs
@@ -93,7 +93,7 @@ mod tests {
             ), // 27
         ];
         for pfx in pfxs.iter().flatten() {
-            tree_bitmap.insert(pfx, PrefixAs(666))?;
+            tree_bitmap.insert(pfx, 0, PrefixAs(666))?;
         }
         println!("------ end of inserts\n");
 

--- a/tests/more-specifics.rs
+++ b/tests/more-specifics.rs
@@ -93,7 +93,7 @@ mod tests {
             ), // 27
         ];
         for pfx in pfxs.iter().flatten() {
-            tree_bitmap.insert(pfx, 0, PrefixAs(666))?;
+            tree_bitmap.insert(pfx, Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(666)))?;
         }
         println!("------ end of inserts\n");
 

--- a/tests/more-specifics.rs
+++ b/tests/more-specifics.rs
@@ -93,7 +93,11 @@ mod tests {
             ), // 27
         ];
         for pfx in pfxs.iter().flatten() {
-            tree_bitmap.insert(pfx, Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(666)))?;
+            tree_bitmap.insert(
+                pfx,
+                Record::new(0, 0, RouteStatus::Active, PrefixAs(666)),
+                None
+            )?;
         }
         println!("------ end of inserts\n");
 

--- a/tests/treebitmap.rs
+++ b/tests/treebitmap.rs
@@ -450,7 +450,7 @@ mod tests {
                     i_len_s += 1;
                     tree_bitmap.insert(pfx, multi_uniq_id, NoMeta::Empty)?;
 
-                    let res_pfx = Prefix::new_relaxed(
+                    let _res_pfx = Prefix::new_relaxed(
                         std::net::Ipv4Addr::new(i_net, 0, 0, 0).into(),
                         i_len_s,
                     );
@@ -462,7 +462,7 @@ mod tests {
                             std::net::Ipv4Addr::new(i_net, 0, 0, 0).into(),
                             s_len,
                         )?;
-                        let res = tree_bitmap.match_prefix(
+                        let _res = tree_bitmap.match_prefix(
                             &pfx,
                             &MatchOptions {
                                 match_type: MatchType::LongestMatch,

--- a/tests/treebitmap.rs
+++ b/tests/treebitmap.rs
@@ -451,7 +451,7 @@ mod tests {
     fn test_multi_ranges_ipv4() -> Result<(), Box<dyn std::error::Error>> {
         crate::common::init();
 
-        let mut tree_bitmap = MultiThreadedStore::<NoMeta>::new()?;
+        let tree_bitmap = MultiThreadedStore::<NoMeta>::new()?;
         for mui in [1_u32, 2, 3, 4, 5] {
             println!("Multi Uniq ID {mui}");
 

--- a/tests/treebitmap.rs
+++ b/tests/treebitmap.rs
@@ -1,4 +1,3 @@
-
 mod common {
     use std::io::Write;
 
@@ -15,8 +14,9 @@ mod tests {
     use std::str::FromStr;
 
     use rotonda_store::{
-        prelude::*, prelude::multi::*, 
-        meta_examples::{ PrefixAs, NoMeta}
+        meta_examples::{NoMeta, PrefixAs},
+        prelude::multi::*,
+        prelude::*,
     };
 
     #[test]
@@ -29,7 +29,9 @@ mod tests {
         .unwrap();
 
         trie.insert(
-            &min_pfx, Record::new(0, 0, RouteStatus::Active, NoMeta::Empty), None
+            &min_pfx,
+            Record::new(0, 0, RouteStatus::Active, NoMeta::Empty),
+            None,
         )?;
         let expect_pfx = Prefix::new_relaxed(
             std::net::Ipv4Addr::new(0, 0, 0, 0).into(),
@@ -44,7 +46,7 @@ mod tests {
                 include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: false,
-                mui: None
+                mui: None,
             },
             guard,
         );
@@ -62,7 +64,7 @@ mod tests {
         trie.insert(
             &max_pfx?,
             Record::new(0, 0, RouteStatus::Active, NoMeta::Empty),
-            None
+            None,
         )?;
         let expect_pfx = Prefix::new_relaxed(
             std::net::Ipv4Addr::new(255, 255, 255, 255).into(),
@@ -77,7 +79,7 @@ mod tests {
                 include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: false,
-                mui: None
+                mui: None,
             },
             guard,
         );
@@ -316,8 +318,8 @@ mod tests {
         for pfx in pfxs.into_iter() {
             tree_bitmap.insert(
                 &pfx?,
-                Record::new(0, 0, RouteStatus::Active,PrefixAs(666)),
-                None
+                Record::new(0, 0, RouteStatus::Active, PrefixAs(666)),
+                None,
             )?;
         }
 
@@ -337,7 +339,7 @@ mod tests {
                     include_withdrawn: false,
                     include_less_specifics: false,
                     include_more_specifics: false,
-                    mui: None
+                    mui: None,
                 },
                 guard,
             );
@@ -352,7 +354,7 @@ mod tests {
                 include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: false,
-                mui: None
+                mui: None,
             },
             guard,
         );
@@ -370,18 +372,20 @@ mod tests {
         let less_specifics = res.less_specifics.unwrap();
 
         assert!(less_specifics.iter().any(|r| {
-            r.prefix == Prefix::new(
-                std::net::Ipv4Addr::new(192, 0, 0, 0).into(),
-                16,
-            )
-            .unwrap()
+            r.prefix
+                == Prefix::new(
+                    std::net::Ipv4Addr::new(192, 0, 0, 0).into(),
+                    16,
+                )
+                .unwrap()
         }));
         assert!(less_specifics.iter().any(|r| {
-            r.prefix == Prefix::new(
-                std::net::Ipv4Addr::new(192, 0, 0, 0).into(),
-                4,
-            )
-            .unwrap()
+            r.prefix
+                == Prefix::new(
+                    std::net::Ipv4Addr::new(192, 0, 0, 0).into(),
+                    4,
+                )
+                .unwrap()
         }));
         Ok(())
     }
@@ -409,7 +413,7 @@ mod tests {
                 tree_bitmap.insert(
                     &pfx,
                     Record::new(0, 0, RouteStatus::Active, NoMeta::Empty),
-                    None
+                    None,
                 )?;
 
                 let res_pfx = Prefix::new_relaxed(
@@ -430,7 +434,7 @@ mod tests {
                             include_withdrawn: false,
                             include_less_specifics: false,
                             include_more_specifics: false,
-                            mui: None
+                            mui: None,
                         },
                         guard,
                     );
@@ -448,11 +452,10 @@ mod tests {
         crate::common::init();
 
         let mut tree_bitmap = MultiThreadedStore::<NoMeta>::new()?;
-        for mui in [1_u32,2,3,4,5] {
+        for mui in [1_u32, 2, 3, 4, 5] {
             println!("Multi Uniq ID {mui}");
 
             for i_net in 0..2 {
-
                 let pfx_vec: Vec<Prefix> = (16..18)
                     .collect::<Vec<u8>>()
                     .into_iter()
@@ -471,8 +474,13 @@ mod tests {
                     i_len_s += 1;
                     tree_bitmap.insert(
                         pfx,
-                        Record::new(mui, 0, RouteStatus::Active, NoMeta::Empty),
-                        None
+                        Record::new(
+                            mui,
+                            0,
+                            RouteStatus::Active,
+                            NoMeta::Empty,
+                        ),
+                        None,
                     )?;
 
                     let _res_pfx = Prefix::new_relaxed(
@@ -494,7 +502,7 @@ mod tests {
                                 include_withdrawn: false,
                                 include_less_specifics: false,
                                 include_more_specifics: false,
-                                mui: Some(mui)
+                                mui: Some(mui),
                             },
                             guard,
                         );
@@ -508,16 +516,22 @@ mod tests {
 
         let guard = &epoch::pin();
         println!("records for mui {}", 5);
-        for rec in tree_bitmap.iter_records_for_mui_v4(5 ,false, guard).collect::<Vec<_>>() {
+        for rec in tree_bitmap
+            .iter_records_for_mui_v4(5, false, guard)
+            .collect::<Vec<_>>()
+        {
             println!("{}", rec);
 
             assert_eq!(rec.meta.len(), 1);
             assert_eq!(rec.meta[0].multi_uniq_id, 5);
             assert_eq!(rec.meta[0].status, RouteStatus::Active);
-        };
-        for rec in tree_bitmap.iter_records_for_mui_v4(1 ,false, guard).collect::<Vec<_>>() {
+        }
+        for rec in tree_bitmap
+            .iter_records_for_mui_v4(1, false, guard)
+            .collect::<Vec<_>>()
+        {
             println!("{}", rec);
-        };
+        }
 
         // println!("all records");
         // for rec in tree_bitmap.prefixes_iter(guard).collect::<Vec<_>>() {
@@ -534,13 +548,17 @@ mod tests {
                 include_withdrawn: true,
                 include_less_specifics: false,
                 include_more_specifics: false,
-                mui: None
+                mui: None,
             },
-            guard
+            guard,
         );
         print!(".pfx {:#?}.", all_recs_for_pfx);
         assert_eq!(all_recs_for_pfx.prefix_meta.len(), 5);
-        let wd_rec = all_recs_for_pfx.prefix_meta.iter().filter(|r| r.status == RouteStatus::Withdrawn).collect::<Vec<_>>();
+        let wd_rec = all_recs_for_pfx
+            .prefix_meta
+            .iter()
+            .filter(|r| r.status == RouteStatus::Withdrawn)
+            .collect::<Vec<_>>();
         assert_eq!(wd_rec.len(), 1);
         assert_eq!(wd_rec[0].multi_uniq_id, 1);
 
@@ -551,40 +569,49 @@ mod tests {
                 include_withdrawn: false,
                 include_less_specifics: false,
                 include_more_specifics: false,
-                mui: None
+                mui: None,
             },
-            guard
+            guard,
         );
         assert_eq!(active_recs_for_pfx.prefix_meta.len(), 4);
-        assert!(!active_recs_for_pfx.prefix_meta.iter().any(|r| r.multi_uniq_id == 1));
+        assert!(!active_recs_for_pfx
+            .prefix_meta
+            .iter()
+            .any(|r| r.multi_uniq_id == 1));
 
         let wd_pfx = Prefix::from_str("1.0.0.0/16")?;
-        tree_bitmap.mark_mui_as_withdrawn_for_prefix(
-            &wd_pfx,
-            2
-        )?;
+        tree_bitmap.mark_mui_as_withdrawn_for_prefix(&wd_pfx, 2)?;
 
         println!("all records");
 
         let all_recs = tree_bitmap.prefixes_iter(guard);
-        
+
         for rec in tree_bitmap.prefixes_iter(guard).collect::<Vec<_>>() {
             println!("{}", rec);
-        };
+        }
 
-        let mui_2_recs = all_recs.filter_map(|r| r.get_record_for_mui(2).cloned());
-        let wd_2_rec = mui_2_recs.filter(|r| r.status == RouteStatus::Withdrawn).collect::<Vec<_>>();
+        let mui_2_recs =
+            all_recs.filter_map(|r| r.get_record_for_mui(2).cloned());
+        let wd_2_rec = mui_2_recs
+            .filter(|r| r.status == RouteStatus::Withdrawn)
+            .collect::<Vec<_>>();
         assert_eq!(wd_2_rec.len(), 1);
         assert_eq!(wd_2_rec[0].multi_uniq_id, 2);
 
-        let mui_2_recs = tree_bitmap.prefixes_iter(guard).filter_map(|r| r.get_record_for_mui(2).cloned().map(|rec| (r.prefix, rec)));
+        let mui_2_recs = tree_bitmap.prefixes_iter(guard).filter_map(|r| {
+            r.get_record_for_mui(2).cloned().map(|rec| (r.prefix, rec))
+        });
         println!("mui_2_recs prefixes_iter");
         for rec in mui_2_recs {
             println!("{} {:#?}", rec.0, rec.1);
         }
-        let mui_2_recs = tree_bitmap.prefixes_iter(guard).filter_map(|r| r.get_record_for_mui(2).cloned().map(|rec| (r.prefix, rec)));
+        let mui_2_recs = tree_bitmap.prefixes_iter(guard).filter_map(|r| {
+            r.get_record_for_mui(2).cloned().map(|rec| (r.prefix, rec))
+        });
 
-        let active_2_rec = mui_2_recs.filter(|r| r.1.status == RouteStatus::Active).collect::<Vec<_>>();
+        let active_2_rec = mui_2_recs
+            .filter(|r| r.1.status == RouteStatus::Active)
+            .collect::<Vec<_>>();
         assert_eq!(active_2_rec.len(), 3);
         assert!(!active_2_rec.iter().any(|r| r.0 == wd_pfx));
 
@@ -594,21 +621,248 @@ mod tests {
             println!("{} {:#?}", rec.prefix, rec.meta);
         }
 
-        let mui_1_recs = tree_bitmap.iter_records_for_mui_v4(1, false, guard).collect::<Vec<_>>();
+        let mui_1_recs = tree_bitmap
+            .iter_records_for_mui_v4(1, false, guard)
+            .collect::<Vec<_>>();
         assert!(mui_1_recs.is_empty());
 
         println!("mui_1_recs iter_records_for_mui_v4");
-        for rec in mui_1_recs {
-            println!("{} {:#?}", rec.prefix, rec.meta);
-        }
+        assert!(mui_1_recs.is_empty());
 
-        let mui_1_recs = tree_bitmap.iter_records_for_mui_v4(1, true, guard).collect::<Vec<_>>();
+        let mui_1_recs = tree_bitmap
+            .iter_records_for_mui_v4(1, true, guard)
+            .collect::<Vec<_>>();
         assert_eq!(mui_1_recs.len(), 4);
         println!("mui_1_recs iter_records_for_mui_v4 w/ withdrawn");
         for rec in mui_1_recs {
-            println!("{} {:#?}", rec.prefix, rec.meta);
             assert_eq!(rec.meta[0].status, RouteStatus::Withdrawn);
         }
+
+        //--------------
+
+        let more_specifics = tree_bitmap.match_prefix(
+            &Prefix::from_str("1.0.0.0/16")?,
+            &MatchOptions {
+                match_type: MatchType::LongestMatch,
+                include_withdrawn: true,
+                include_less_specifics: false,
+                include_more_specifics: true,
+                mui: None,
+            },
+            guard,
+        );
+
+        println!("more_specifics match {} w/ withdrawn", more_specifics);
+        let more_specifics = more_specifics.more_specifics.unwrap();
+        assert_eq!(more_specifics.len(), 1);
+        assert_eq!(more_specifics.v4.len(), 1);
+        let more_specifics = &more_specifics.v4[0];
+        assert_eq!(more_specifics.prefix, Prefix::from_str("1.0.0.0/17")?);
+        assert_eq!(more_specifics.meta.len(), 5);
+        assert_eq!(
+            more_specifics
+                .meta
+                .iter()
+                .filter(|r| r.status == RouteStatus::Active)
+                .collect::<Vec<_>>()
+                .len(),
+            4
+        );
+        let rec = more_specifics
+            .meta
+            .iter()
+            .filter(|r| r.status == RouteStatus::Withdrawn)
+            .collect::<Vec<_>>();
+        assert_eq!(rec.len(), 1);
+        assert_eq!(rec[0].multi_uniq_id, 1);
+
+        //---------------
+
+        let more_specifics = tree_bitmap.match_prefix(
+            &Prefix::from_str("1.0.0.0/16")?,
+            &MatchOptions {
+                match_type: MatchType::LongestMatch,
+                include_withdrawn: false,
+                include_less_specifics: false,
+                include_more_specifics: true,
+                mui: None,
+            },
+            guard,
+        );
+
+        println!("more_specifics match {} w/o withdrawn", more_specifics);
+        let more_specifics = more_specifics.more_specifics.unwrap();
+        assert_eq!(more_specifics.len(), 1);
+        assert_eq!(more_specifics.v4.len(), 1);
+        let more_specifics = &more_specifics.v4[0];
+        assert_eq!(more_specifics.prefix, Prefix::from_str("1.0.0.0/17")?);
+        assert_eq!(more_specifics.meta.len(), 4);
+        assert_eq!(
+            more_specifics
+                .meta
+                .iter()
+                .filter(|r| r.status == RouteStatus::Active)
+                .collect::<Vec<_>>()
+                .len(),
+            4
+        );
+        let rec = more_specifics
+            .meta
+            .iter()
+            .filter(|r| r.status == RouteStatus::Withdrawn)
+            .collect::<Vec<_>>();
+        assert!(rec.is_empty());
+
+        //------------------
+
+        tree_bitmap.mark_mui_as_withdrawn_for_prefix(&wd_pfx, 1)?;
+        tree_bitmap.mark_mui_as_active_v4(1)?;
+
+        let more_specifics = tree_bitmap.match_prefix(
+            &Prefix::from_str("1.0.0.0/16")?,
+            &MatchOptions {
+                match_type: MatchType::LongestMatch,
+                include_withdrawn: false,
+                include_less_specifics: false,
+                include_more_specifics: true,
+                mui: None,
+            },
+            guard,
+        );
+
+        println!("more_specifics match w/o withdrawn #2 {}", more_specifics);
+        // We withdrew mui 1 for the requested prefix itself, since mui 2 was
+        // already withdrawn above, we're left with 3 records
+        assert_eq!(more_specifics.prefix_meta.len(), 3);
+
+        let more_specifics = more_specifics.more_specifics.unwrap();
+        assert_eq!(more_specifics.len(), 1);
+        assert_eq!(more_specifics.v4.len(), 1);
+        let more_specifics = &more_specifics.v4[0];
+        assert_eq!(more_specifics.prefix, Prefix::from_str("1.0.0.0/17")?);
+
+        // one more more_specific should have been added due to mui 1 being
+        // Active again, for all but the requested prefix above.
+        assert_eq!(more_specifics.meta.len(), 5);
+        assert_eq!(
+            more_specifics
+                .meta
+                .iter()
+                .filter(|r| r.status == RouteStatus::Active)
+                .collect::<Vec<_>>()
+                .len(),
+            5
+        );
+
+        // we didn't ask to see withdrawn routes
+        let rec = more_specifics
+            .meta
+            .iter()
+            .filter(|r| r.status == RouteStatus::Withdrawn)
+            .collect::<Vec<_>>();
+        assert!(rec.is_empty());
+
+        // withdraw muis 2,3,4,5 for the requested prefix
+        tree_bitmap.mark_mui_as_withdrawn_for_prefix(&wd_pfx, 2)?;
+        tree_bitmap.mark_mui_as_withdrawn_for_prefix(&wd_pfx, 3)?;
+        tree_bitmap.mark_mui_as_withdrawn_for_prefix(&wd_pfx, 4)?;
+        tree_bitmap.mark_mui_as_withdrawn_for_prefix(&wd_pfx, 5)?;
+
+        let more_specifics = tree_bitmap.match_prefix(
+            &Prefix::from_str("1.0.0.0/16")?,
+            &MatchOptions {
+                match_type: MatchType::ExactMatch,
+                include_withdrawn: false,
+                include_less_specifics: false,
+                include_more_specifics: true,
+                mui: None,
+            },
+            guard,
+        );
+        println!("more_specifics match w/o withdrawn #3 {}", more_specifics);
+
+        // This prefix should not be found, since we withdrew all records for it.
+        assert!(more_specifics.prefix_meta.is_empty());
+
+        // ..as a result, its resulting match_type should be EmptyMatch
+        assert_eq!(more_specifics.match_type, MatchType::EmptyMatch);
+
+        let more_specifics = more_specifics.more_specifics.unwrap();
+        assert_eq!(more_specifics.len(), 1);
+        assert_eq!(more_specifics.v4.len(), 1);
+        let more_specifics = &more_specifics.v4[0];
+        assert_eq!(more_specifics.prefix, Prefix::from_str("1.0.0.0/17")?);
+
+        // all muis should be visible for the more specifics
+        assert_eq!(more_specifics.meta.len(), 5);
+        assert_eq!(
+            more_specifics
+                .meta
+                .iter()
+                .filter(|r| r.status == RouteStatus::Active)
+                .collect::<Vec<_>>()
+                .len(),
+            5
+        );
+
+        // we didn't ask to see withdrawn routes,
+        let rec = more_specifics
+            .meta
+            .iter()
+            .filter(|r| r.status == RouteStatus::Withdrawn)
+            .collect::<Vec<_>>();
+        assert!(rec.is_empty());
+
+        //----------------------
+
+        // Change the requested prefix to the more specific from the former
+        // queries.
+        let less_specifics = tree_bitmap.match_prefix(
+            &Prefix::from_str("1.0.0.0/17")?,
+            &MatchOptions {
+                match_type: MatchType::ExactMatch,
+                include_withdrawn: false,
+                include_less_specifics: true,
+                include_more_specifics: false,
+                mui: None,
+            },
+            guard,
+        );
+
+        println!("less_specifics match w/o withdrawn #4 {}", less_specifics);
+
+        assert_eq!(less_specifics.prefix_meta.len(), 5);
+
+        let less_specifics = less_specifics.less_specifics.unwrap();
+        // All records for the less specific /16 are withdrawn, so this should be empty.
+        assert!(less_specifics.is_empty());
+        
+
+        //--------------------
+
+        tree_bitmap.mark_mui_as_active_for_prefix(&wd_pfx, 5)?;
+
+        let less_specifics = tree_bitmap.match_prefix(
+            &Prefix::from_str("1.0.0.0/17")?,
+            &MatchOptions {
+                match_type: MatchType::ExactMatch,
+                include_withdrawn: false,
+                include_less_specifics: true,
+                include_more_specifics: false,
+                mui: None,
+            },
+            guard,
+        );
+        println!("more_specifics match w/o withdrawn #5 {}", less_specifics);
+        let less_specifics = less_specifics.less_specifics.unwrap();
+
+        assert_eq!(less_specifics.v4.len(), 1);
+        let less_specifics = &less_specifics.v4[0];
+        assert_eq!(less_specifics.prefix, Prefix::from_str("1.0.0.0/16")?);
+        // We should only see the record for mui 5
+        assert_eq!(less_specifics.meta.len(), 1);
+        assert_eq!(less_specifics.meta[0].multi_uniq_id, 5);
+        assert_eq!(less_specifics.meta[0].status, RouteStatus::Active);
 
         Ok(())
     }

--- a/tests/treebitmap.rs
+++ b/tests/treebitmap.rs
@@ -26,7 +26,7 @@ mod tests {
         )
         .unwrap();
 
-        trie.insert(&min_pfx, 0, NoMeta::Empty)?;
+        trie.insert(&min_pfx, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
         let expect_pfx = Prefix::new_relaxed(
             std::net::Ipv4Addr::new(0, 0, 0, 0).into(),
             1,
@@ -54,7 +54,7 @@ mod tests {
         );
 
         // drop(locks);
-        trie.insert(&max_pfx?, 0, NoMeta::Empty)?;
+        trie.insert(&max_pfx?, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
         let expect_pfx = Prefix::new_relaxed(
             std::net::Ipv4Addr::new(255, 255, 255, 255).into(),
             32,
@@ -304,7 +304,7 @@ mod tests {
         ];
 
         for pfx in pfxs.into_iter() {
-            tree_bitmap.insert(&pfx?, 0, PrefixAs(666))?;
+            tree_bitmap.insert(&pfx?, Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(666)))?;
         }
 
         // let (store_v4, store_v6) = tree_bitmap.acquire_prefixes_rwlock_read();
@@ -390,7 +390,7 @@ mod tests {
             let mut i_len_s = 0;
             for pfx in pfx_vec {
                 i_len_s += 1;
-                tree_bitmap.insert(&pfx, 0, NoMeta::Empty)?;
+                tree_bitmap.insert(&pfx, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
 
                 let res_pfx = Prefix::new_relaxed(
                     std::net::Ipv4Addr::new(i_net, 0, 0, 0).into(),
@@ -448,7 +448,7 @@ mod tests {
 
                 for pfx in &pfx_vec {
                     i_len_s += 1;
-                    tree_bitmap.insert(pfx, multi_uniq_id, NoMeta::Empty)?;
+                    tree_bitmap.insert(pfx, Record::new(multi_uniq_id, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
 
                     let _res_pfx = Prefix::new_relaxed(
                         std::net::Ipv4Addr::new(i_net, 0, 0, 0).into(),

--- a/tests/treebitmap.rs
+++ b/tests/treebitmap.rs
@@ -26,7 +26,9 @@ mod tests {
         )
         .unwrap();
 
-        trie.insert(&min_pfx, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
+        trie.insert(
+            &min_pfx, Record::new(0, 0, RouteStatus::Active, NoMeta::Empty), None
+        )?;
         let expect_pfx = Prefix::new_relaxed(
             std::net::Ipv4Addr::new(0, 0, 0, 0).into(),
             1,
@@ -54,7 +56,11 @@ mod tests {
         );
 
         // drop(locks);
-        trie.insert(&max_pfx?, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
+        trie.insert(
+            &max_pfx?,
+            Record::new(0, 0, RouteStatus::Active, NoMeta::Empty),
+            None
+        )?;
         let expect_pfx = Prefix::new_relaxed(
             std::net::Ipv4Addr::new(255, 255, 255, 255).into(),
             32,
@@ -304,7 +310,11 @@ mod tests {
         ];
 
         for pfx in pfxs.into_iter() {
-            tree_bitmap.insert(&pfx?, Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(666)))?;
+            tree_bitmap.insert(
+                &pfx?,
+                Record::new(0, 0, RouteStatus::Active,PrefixAs(666)),
+                None
+            )?;
         }
 
         // let (store_v4, store_v6) = tree_bitmap.acquire_prefixes_rwlock_read();
@@ -390,7 +400,11 @@ mod tests {
             let mut i_len_s = 0;
             for pfx in pfx_vec {
                 i_len_s += 1;
-                tree_bitmap.insert(&pfx, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
+                tree_bitmap.insert(
+                    &pfx,
+                    Record::new(0, 0, RouteStatus::Active, NoMeta::Empty),
+                    None
+                )?;
 
                 let res_pfx = Prefix::new_relaxed(
                     std::net::Ipv4Addr::new(i_net, 0, 0, 0).into(),
@@ -448,7 +462,11 @@ mod tests {
 
                 for pfx in &pfx_vec {
                     i_len_s += 1;
-                    tree_bitmap.insert(pfx, Record::new(multi_uniq_id, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
+                    tree_bitmap.insert(
+                        pfx,
+                        Record::new(multi_uniq_id, 0, RouteStatus::Active, NoMeta::Empty),
+                        None
+                    )?;
 
                     let _res_pfx = Prefix::new_relaxed(
                         std::net::Ipv4Addr::new(i_net, 0, 0, 0).into(),

--- a/tests/treebitmap.rs
+++ b/tests/treebitmap.rs
@@ -39,9 +39,10 @@ mod tests {
             &expect_pfx?,
             &MatchOptions {
                 match_type: MatchType::LongestMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: false,
+                mui: None
             },
             guard,
         );
@@ -71,9 +72,10 @@ mod tests {
             &expect_pfx?,
             &MatchOptions {
                 match_type: MatchType::ExactMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: false,
+                mui: None
             },
             guard,
         );
@@ -330,9 +332,10 @@ mod tests {
                 &pfx.prefix,
                 &MatchOptions {
                     match_type: MatchType::LongestMatch,
-                    include_all_records: false,
+                    include_withdrawn: false,
                     include_less_specifics: false,
                     include_more_specifics: false,
+                    mui: None
                 },
                 guard,
             );
@@ -344,9 +347,10 @@ mod tests {
             &Prefix::new(std::net::Ipv4Addr::new(192, 0, 1, 0).into(), 24)?,
             &MatchOptions {
                 match_type: MatchType::LongestMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: false,
+                mui: None
             },
             guard,
         );
@@ -421,9 +425,10 @@ mod tests {
                         &pfx,
                         &MatchOptions {
                             match_type: MatchType::LongestMatch,
-                            include_all_records: false,
+                            include_withdrawn: false,
                             include_less_specifics: false,
                             include_more_specifics: false,
+                            mui: None
                         },
                         guard,
                     );
@@ -484,9 +489,10 @@ mod tests {
                             &pfx,
                             &MatchOptions {
                                 match_type: MatchType::LongestMatch,
-                                include_all_records: false,
+                                include_withdrawn: false,
                                 include_less_specifics: false,
                                 include_more_specifics: false,
+                                mui: None
                             },
                             guard,
                         );
@@ -499,7 +505,11 @@ mod tests {
         }
 
         let guard = &epoch::pin();
-        for pfx in tree_bitmap.more_specifics_iter_from(&rotonda_store::prelude::Prefix::new("0.0.0.0".parse::<std::net::Ipv4Addr>().unwrap().into(),0).unwrap(), guard) {
+        for pfx in tree_bitmap.more_specifics_iter_from(
+            &rotonda_store::prelude::Prefix::new("0.0.0.0".parse::<std::net::Ipv4Addr>().unwrap().into(),0).unwrap(),
+            None,
+            guard
+        ) {
             print!(".pfx {:?}.", pfx);
         };
         Ok(())

--- a/tests/treebitmap_v6.rs
+++ b/tests/treebitmap_v6.rs
@@ -17,7 +17,7 @@ mod tests {
         )
         .unwrap();
 
-        trie.insert(&a_pfx, NoMeta::Empty)?;
+        trie.insert(&a_pfx, 0, NoMeta::Empty)?;
         let expect_pfx = Prefix::new_relaxed(
             ("2001:67c:1bfc::").parse::<std::net::Ipv6Addr>()?.into(),
             48,
@@ -49,7 +49,7 @@ mod tests {
         )
         .unwrap();
 
-        trie.insert(&min_pfx, NoMeta::Empty)?;
+        trie.insert(&min_pfx, 0, NoMeta::Empty)?;
         let expect_pfx = Prefix::new_relaxed(
             ("0::").parse::<std::net::Ipv6Addr>()?.into(),
             1,
@@ -78,7 +78,7 @@ mod tests {
         );
 
         // drop(locks);
-        trie.insert(&max_pfx?, NoMeta::Empty)?;
+        trie.insert(&max_pfx?, 0, NoMeta::Empty)?;
         let expect_pfx = Prefix::new_relaxed(
             std::net::Ipv6Addr::new(255, 255, 255, 255, 255, 255, 255, 255)
                 .into(),
@@ -244,7 +244,7 @@ mod tests {
         ];
 
         for pfx in pfxs.into_iter() {
-            tree_bitmap.insert(&pfx?, PrefixAs(666))?;
+            tree_bitmap.insert(&pfx?, 0, PrefixAs(666))?;
         }
 
         let guard = &epoch::pin();
@@ -500,7 +500,7 @@ mod tests {
         ];
 
         for pfx in pfxs.into_iter() {
-            tree_bitmap.insert(&pfx?, PrefixAs(666))?;
+            tree_bitmap.insert(&pfx?, 0, PrefixAs(666))?;
         }
 
         // let (store_v4, store_v6) = tree_bitmap.acquire_prefixes_rwlock_read();
@@ -590,7 +590,7 @@ mod tests {
             let mut i_len_s = 0;
             for pfx in pfx_vec {
                 i_len_s += 1;
-                tree_bitmap.insert(&pfx, NoMeta::Empty)?;
+                tree_bitmap.insert(&pfx, 0, NoMeta::Empty)?;
 
                 let res_pfx = Prefix::new_relaxed(
                     std::net::Ipv6Addr::new(i_net, 0, 0, 0, 0, 0, 0, 0)

--- a/tests/treebitmap_v6.rs
+++ b/tests/treebitmap_v6.rs
@@ -3,7 +3,7 @@ mod tests {
     use rotonda_store::{
         prelude::*, prelude::multi::*, 
         meta_examples::PrefixAs,
-        meta_examples::NoMeta
+        meta_examples::NoMeta,
     };
 
     #[test]
@@ -17,7 +17,7 @@ mod tests {
         )
         .unwrap();
 
-        trie.insert(&a_pfx, 0, NoMeta::Empty)?;
+        trie.insert(&a_pfx, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
         let expect_pfx = Prefix::new_relaxed(
             ("2001:67c:1bfc::").parse::<std::net::Ipv6Addr>()?.into(),
             48,
@@ -49,7 +49,7 @@ mod tests {
         )
         .unwrap();
 
-        trie.insert(&min_pfx, 0, NoMeta::Empty)?;
+        trie.insert(&min_pfx, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
         let expect_pfx = Prefix::new_relaxed(
             ("0::").parse::<std::net::Ipv6Addr>()?.into(),
             1,
@@ -78,7 +78,7 @@ mod tests {
         );
 
         // drop(locks);
-        trie.insert(&max_pfx?, 0, NoMeta::Empty)?;
+        trie.insert(&max_pfx?, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
         let expect_pfx = Prefix::new_relaxed(
             std::net::Ipv6Addr::new(255, 255, 255, 255, 255, 255, 255, 255)
                 .into(),
@@ -244,7 +244,7 @@ mod tests {
         ];
 
         for pfx in pfxs.into_iter() {
-            tree_bitmap.insert(&pfx?, 0, PrefixAs(666))?;
+            tree_bitmap.insert(&pfx?, Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(666)))?;
         }
 
         let guard = &epoch::pin();
@@ -500,7 +500,7 @@ mod tests {
         ];
 
         for pfx in pfxs.into_iter() {
-            tree_bitmap.insert(&pfx?, 0, PrefixAs(666))?;
+            tree_bitmap.insert(&pfx?, Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(666)))?;
         }
 
         // let (store_v4, store_v6) = tree_bitmap.acquire_prefixes_rwlock_read();
@@ -590,7 +590,7 @@ mod tests {
             let mut i_len_s = 0;
             for pfx in pfx_vec {
                 i_len_s += 1;
-                tree_bitmap.insert(&pfx, 0, NoMeta::Empty)?;
+                tree_bitmap.insert(&pfx, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
 
                 let res_pfx = Prefix::new_relaxed(
                     std::net::Ipv6Addr::new(i_net, 0, 0, 0, 0, 0, 0, 0)

--- a/tests/treebitmap_v6.rs
+++ b/tests/treebitmap_v6.rs
@@ -17,7 +17,7 @@ mod tests {
         )
         .unwrap();
 
-        trie.insert(&a_pfx, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
+        trie.insert(&a_pfx, Record::new(0, 0, RouteStatus::Active, NoMeta::Empty), None)?;
         let expect_pfx = Prefix::new_relaxed(
             ("2001:67c:1bfc::").parse::<std::net::Ipv6Addr>()?.into(),
             48,
@@ -49,7 +49,11 @@ mod tests {
         )
         .unwrap();
 
-        trie.insert(&min_pfx, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
+        trie.insert(
+            &min_pfx,
+            Record::new(0, 0, RouteStatus::Active, NoMeta::Empty),
+            None
+        )?;
         let expect_pfx = Prefix::new_relaxed(
             ("0::").parse::<std::net::Ipv6Addr>()?.into(),
             1,
@@ -78,7 +82,7 @@ mod tests {
         );
 
         // drop(locks);
-        trie.insert(&max_pfx?, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
+        trie.insert(&max_pfx?, Record::new(0, 0, RouteStatus::Active, NoMeta::Empty), None)?;
         let expect_pfx = Prefix::new_relaxed(
             std::net::Ipv6Addr::new(255, 255, 255, 255, 255, 255, 255, 255)
                 .into(),
@@ -244,7 +248,7 @@ mod tests {
         ];
 
         for pfx in pfxs.into_iter() {
-            tree_bitmap.insert(&pfx?, Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(666)))?;
+            tree_bitmap.insert(&pfx?, Record::new(0, 0, RouteStatus::Active, PrefixAs(666)), None)?;
         }
 
         let guard = &epoch::pin();
@@ -500,7 +504,11 @@ mod tests {
         ];
 
         for pfx in pfxs.into_iter() {
-            tree_bitmap.insert(&pfx?, Record::new(0, 0, RouteStatus::InConvergence, PrefixAs(666)))?;
+            tree_bitmap.insert(
+                &pfx?,
+                Record::new(0, 0, RouteStatus::Active, PrefixAs(666)),
+                None
+            )?;
         }
 
         // let (store_v4, store_v6) = tree_bitmap.acquire_prefixes_rwlock_read();
@@ -590,7 +598,11 @@ mod tests {
             let mut i_len_s = 0;
             for pfx in pfx_vec {
                 i_len_s += 1;
-                tree_bitmap.insert(&pfx, Record::new(0, 0, RouteStatus::InConvergence, NoMeta::Empty))?;
+                tree_bitmap.insert(
+                    &pfx,
+                    Record::new(0, 0, RouteStatus::Active, NoMeta::Empty),
+                    None
+                )?;
 
                 let res_pfx = Prefix::new_relaxed(
                     std::net::Ipv6Addr::new(i_net, 0, 0, 0, 0, 0, 0, 0)

--- a/tests/treebitmap_v6.rs
+++ b/tests/treebitmap_v6.rs
@@ -26,9 +26,10 @@ mod tests {
             &expect_pfx?,
             &MatchOptions {
                 match_type: MatchType::LongestMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: false,
+                mui: None
             },
             guard,
         );
@@ -64,9 +65,10 @@ mod tests {
             &expect_pfx?,
             &MatchOptions {
                 match_type: MatchType::LongestMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: false,
+                mui: None
             },
             guard,
         );
@@ -94,9 +96,10 @@ mod tests {
             &expect_pfx?,
             &MatchOptions {
                 match_type: MatchType::ExactMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: false,
+                mui: None
             },
             guard,
         );
@@ -258,9 +261,10 @@ mod tests {
                 &pfx.prefix,
                 &MatchOptions {
                     match_type: MatchType::LongestMatch,
-                    include_all_records: false,
+                    include_withdrawn: false,
                     include_less_specifics: false,
                     include_more_specifics: false,
+                    mui: None
                 },
                 guard,
             );
@@ -524,9 +528,10 @@ mod tests {
                 &pfx.prefix,
                 &MatchOptions {
                     match_type: MatchType::LongestMatch,
-                    include_all_records: false,
+                    include_withdrawn: false,
                     include_less_specifics: false,
                     include_more_specifics: false,
+                    mui: None,
                 },
                 guard,
             );
@@ -541,9 +546,10 @@ mod tests {
             )?,
             &MatchOptions {
                 match_type: MatchType::LongestMatch,
-                include_all_records: false,
+                include_withdrawn: false,
                 include_less_specifics: true,
                 include_more_specifics: false,
+                mui: None,
             },
             guard,
         );
@@ -621,9 +627,10 @@ mod tests {
                         &pfx,
                         &MatchOptions {
                             match_type: MatchType::LongestMatch,
-                            include_all_records: false,
+                            include_withdrawn: false,
                             include_less_specifics: false,
                             include_more_specifics: false,
+                            mui: None
                         },
                         guard,
                     );


### PR DESCRIPTION
Move the leaf data structure from rotonda (HashMap keyed on peer ids) to the store, since updating them in the store would be more efficient (not having to clone and replace the complete HashMap). We're using a flurry map (a concurrent hashmap) in for that.

We are also replacing the BTreeSet<Prefix> in Rotonda with bitmap indexes in the store, to iterate for one peer id more efficiently over the complete concurrent RIB in the store.