### PR TITLE
Release 0.4.0 rc0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["routing", "bgp"]
 license = "BSD-3-Clause"
 name = "rotonda-store"
 repository = "https://github.com/NLnetLabs/rotonda-store/"
-version = "0.4.1-dev"
+version = "0.4.0-rc0"
 rust-version = "1.71"
 
 [dependencies]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,17 +1,23 @@
 # Change Log
 
-## Unreleased new version
+## 0.4.0-rc0
 
 Breaking changes
 
+* Removed `MergeUpdate` trait
+
 New
+
+* Leaves now are HashMaps keyed on multi_uniq_ids (`mui`)
+* Facilities for best (and backup) path selection for a prefix
+* Facilities for iterating over and searching for values for (prefix, mui)
+  combinations
 
 Bug fixes
 
 Other changes
 
-* Use inetnum::addr::Prefix, instead of routecore::addr::Prefix
-* Remove routecore dependency
+* Use inetnum structs instead of routecore (Asn, Prefix)
 
 ## 0.3.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.4.0-rc0
 
+Released 2024-06-12.
+
 Breaking changes
 
 * Removed `MergeUpdate` trait

--- a/src/local_array/store/atomic_types.rs
+++ b/src/local_array/store/atomic_types.rs
@@ -420,20 +420,6 @@ pub struct MultiMap<M: Meta>(
     pub(crate) flurry::HashMap<u32, MultiMapValue<M>>,
 );
 
-pub struct IdOrderable<T>(pub u32, T);
-
-impl<T: PartialOrd + Eq + PartialEq> PartialOrd for IdOrderable<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.1.partial_cmp(&other.1)
-    }
-}
-
-impl<T: PartialOrd + Eq + PartialOrd> PartialEq for IdOrderable<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.1 == other.1
-    }
-}
-
 impl<M: Send + Sync + Debug + Display + Meta> MultiMap<M> {
     pub(crate) fn new(record_map: HashMap<u32, MultiMapValue<M>>) -> Self {
         Self(record_map)


### PR DESCRIPTION
## 0.4.0-rc0

Released 2024-06-12.

Breaking changes

* Removed `MergeUpdate` trait

New

* Leaves now are HashMaps keyed on multi_uniq_ids (`mui`)
* Facilities for best (and backup) path selection for a prefix
* Facilities for iterating over and searching for values for (prefix, mui)
  combinations