### PR TITLE
Release 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ crossbeam-utils = "^0.8"
 inetnum   = "0.1"
 log       = "^0.4"
 roaring 	= "0.10.3"
-rotonda-macros = { path = "proc_macros", version = "0.4.0" }
+rotonda-macros = { path = "proc_macros" }
 routecore       = { version = "0.5", features = ["bgp", "bmp", "fsm", "serde"] }
 
 ansi_term   = { version = "0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ crossbeam-utils = "^0.8"
 inetnum   = "0.1"
 log       = "^0.4"
 roaring 	= "0.10.3"
-rotonda-macros  = { path = "proc_macros" }
+rotonda-macros = { path = "proc_macros", version = "0.4.0" }
 routecore       = { version = "0.5", features = ["bgp", "bmp", "fsm", "serde"] }
 
 ansi_term   = { version = "0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ crossbeam-utils = "^0.8"
 inetnum   = "0.1"
 log       = "^0.4"
 roaring 	= "0.10.3"
-rotonda-macros = { path = "proc_macros" }
+rotonda-macros = { path = "proc_macros", version = "0.4.0" }
 routecore       = { version = "0.5", features = ["bgp", "bmp", "fsm", "serde"] }
 
 ansi_term   = { version = "0.12", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ documentation = "https://docs.rs/rotonda/"
 homepage = "https://nlnetlabs.nl/projects/routing/rotonda/"
 keywords = ["routing", "bgp"]
 name = "rotonda-store"
-# version = "0.4.0-rc1"
 repository = "https://github.com/NLnetLabs/rotonda-store/"
 version.workspace = true
 edition.workspace = true
@@ -17,7 +16,7 @@ license.workspace = true
 members   = ["proc_macros"]
 
 [workspace.package]
-version = "0.4.0-rc1"
+version = "0.4.0"
 edition = "2021"
 authors = ["NLnet Labs <routing-team@nlnetlabs.nl>"]
 license = "BSD-3-Clause"
@@ -27,11 +26,11 @@ rust-version = "1.80"
 crossbeam-epoch = "^0.9"
 crossbeam-utils = "^0.8"
 
-inetnum   = "0.1.0"
+inetnum   = "0.1"
 log       = "^0.4"
 roaring 	= "0.10.3"
-rotonda-macros  = { path = "proc_macros", version = "0.4.0-rc1" }
-routecore       = { version = "0.5.0-rc1", features = ["bgp", "bmp", "fsm", "serde"] }
+rotonda-macros  = { path = "proc_macros" }
+routecore       = { version = "0.5", features = ["bgp", "bmp", "fsm", "serde"] }
 
 ansi_term   = { version = "0.12", optional = true }
 csv         = { version = "1", optional = true }

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## 0.4.0-rc0
+## 0.4.0
 
-Released 2024-06-12.
+Released 2024-11-20.
 
 Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # `rotonda-store`
 
-In-memory IP prefixes storage and retrieval. Part of the `Rotonda` modular BGP engine.
+An In-Memory Routing Information Base (`RIB`) for IPv4 and IPv6 Prefixes. Part
+of the `Rotonda` modular BGP engine.
 
-A `rotonda-store` is a data structure that stores both IPv4 and IPv6 prefixes together with arbitrary
-meta-data in a tree-bitmap[^1]. The tree-bitmap allows for fast querying of IP prefixes and their more- 
-and less-specific prefixes.
+Although this store is geared towards storing routing information, it can
+store any type of metadata for a prefix.
 
-This crate provides a data-structure intended for single-threaded use, and a data-structure for 
-multi-threaded use.
+It features as secondary key a u32 value, which can be used to store multiple
+values for one prefix, e.g. representing different peers, or add_path routes.
+
+The built-in tree-bitmap[^1] allows for fast querying of IP prefixes and their
+more- and less-specific prefixes.
+
+This crate provides a data-structure intended for single-threaded use, and a
+data-structure for  multi-threaded use.
 
 [^1]: Read more about the data-structure in this [blog post](https://blog.nlnetlabs.nl/donkeys-mules-horses/).


### PR DESCRIPTION
Released 2024-11-20.

Breaking changes

* Removed `MergeUpdate` trait

New

* Leaves now are HashMaps keyed on multi_uniq_ids (`mui`)
* Facilities for best (and backup) path selection for a prefix
* Facilities for iterating over and searching for values for (prefix, mui)
  combinations

Bug fixes

Other changes

* Use inetnum structs instead of routecore (Asn, Prefix)