### PR TITLE
Release 0.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         # according to Cargo.toml. Test against beta and nightly Rust to get
         # early warning of any problems that might occur with the upcoming Rust
         # release. Ordered oldest Rust to newest Rust.
-        rust: [1.80.0, stable, beta, nightly]
+        rust: [1.82.0, stable, beta, nightly]
 
         # Test with no features, default features ("") and all features.
         # Ordered fewest features to most features.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.4.1"
 edition = "2021"
 authors = ["NLnet Labs <routing-team@nlnetlabs.nl>"]
 license = "BSD-3-Clause"
-rust-version = "1.80"
+rust-version = "1.82"
 
 [dependencies]
 crossbeam-epoch = "^0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,12 @@ default = []
 [[bin]]
 name = "cli"
 required-features = ["cli"]
+
+[lints.clippy]
+needless_lifetimes = "allow"
+extra_unused_lifetimes = "allow"
+empty_line_after_outer_attr = "allow"
+empty_line_after_doc_comments = "allow"
+
+[lints.rust]
+elided_named_lifetimes = "allow"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,12 @@
 # Change Log
 
-## Unreleased new version
+## 0.4.1
 
-Release yyyy-mm-yy.
-
-Breaking changes
-
-New
+Release 2025-01-29.
 
 Bug fixes
+
+* Incorrect Error message in case the status of a prefix was modified without it actually existing in the store, is now fixed. It was `StoreNotReady`, it has been changed to `PrefixNotFound`.
 
 ## 0.4.0
 


### PR DESCRIPTION
Released 2025-01-29.

Bug fixes

* Incorrect Error message in case the status of a prefix was modified without it actually existing in the store, is now fixed. It was `StoreNotReady`, it has been changed to `PrefixNotFound`.